### PR TITLE
Fixes #17103 Fix the empty combobox

### DIFF
--- a/form/_FormSelectWidget.js
+++ b/form/_FormSelectWidget.js
@@ -636,6 +636,8 @@ define([
 
 			// Make our event connections for updating state
 			aspect.after(this, "onChange", lang.hitch(this, "_updateSelection"));
+			// do _loadChildren after startup to set label correctly for CheckedMultiSelect
+			aspect.after(this, "startup", lang.hitch(this, "_loadChildren"));
 
 			// moved from startup
 			//		Connects in our store, if we have one defined
@@ -646,12 +648,6 @@ define([
 				this.store = null;
 				this.setStore(store, this._oValue);
 			}
-		},
-
-		startup: function(){
-			// summary:
-			this._loadChildren();
-			this.inherited(arguments);
 		},
 
 		destroy: function(){


### PR DESCRIPTION
This fix is for the problem with the the initial combobox label being empty, it is fixed in dijit/form/_FormSelectWidget.js.  There is another part of the fix in dojox/form/CheckedMultiSelect.js which has to do with the menu not displaying the checkboxes, and it also has updated the mvc test which tests the problem which introduced this problem (the empty combobox), to be sure this fix for this does not regress that.
