### PR TITLE
HorizontalSlider: enforce min/max limits on set()

### DIFF
--- a/form/HorizontalSlider.js
+++ b/form/HorizontalSlider.js
@@ -205,10 +205,10 @@ define([
 			// summary:
 			//		Hook so set('value', value) works.
 
-			//-- Force limit incomming value to be within min/max limits
-			if ( value > this.maximum ) {
+			// Force limit incomming value to be within min/max limits
+			if(value > this.maximum){
 				value = this.maximum;
-			} else if ( value < this.minimum ) {
+			}else if( value < this.minimum){
 				value = this.minimum;
 			}
 


### PR DESCRIPTION
Current behavior permits calling set() with values outside on set
min/max limits, causing widget visual corruption.

IBM Internal RTC Bug Report #11007
