### PR TITLE
Fixes #17431 LinkDialog not creating links in IE11. I have added code to...

### DIFF
--- a/_editor/RichText.js
+++ b/_editor/RichText.js
@@ -2164,7 +2164,30 @@ define([
 			//		protected
 			argument = this._preFilterContent(argument);
 			var rv = true;
-			if(has("ie") < 9){
+			if(has("ie") >= 9){
+				var insertRange;
+				var selection = rangeapi.getSelection(this.window);
+				if(selection && selection.rangeCount && selection.getRangeAt){
+					insertRange = selection.getRangeAt(0);
+					insertRange.deleteContents();
+
+					var div = domConstruct.create('div');
+					div.innerHTML = argument;
+					var node, lastNode;
+					var n = this.document.createDocumentFragment();
+					while((node = div.firstChild)){
+						lastNode = n.appendChild(node);
+					}
+					insertRange.insertNode(n);
+					if(lastNode) {
+						insertRange = insertRange.cloneRange();
+						insertRange.setStartAfter(lastNode);
+						insertRange.collapse(false);
+						selection.removeAllRanges();
+						selection.addRange(insertRange);
+					}
+				}
+			}else if(has("ie") < 9){
 				var insertRange = this.document.selection.createRange();
 				if(this.document.selection.type.toUpperCase() === 'CONTROL'){
 					var n = insertRange.item(0);


### PR DESCRIPTION
... handle IE >= 9 separately, in order to continue to use execCommand(inserthtml) for browsers other than IE.

https://bugs.dojotoolkit.org/ticket/17431
