### PR TITLE
prevent from querying for empty string when FilteringSelect value is set to null

### DIFF
--- a/form/FilteringSelect.js
+++ b/form/FilteringSelect.js
@@ -127,7 +127,7 @@ define([
 				if(value === null || value === ''){
 					value = '';
 					if(!lang.isString(displayedValue)){
-						this._setDisplayedValueAttr(displayedValue||'', priorityChange);
+						this._setDisplayedValueAttr(displayedValue||null, priorityChange);
 						return;
 					}
 				}
@@ -166,8 +166,14 @@ define([
 			// description:
 			//		Sets textbox to display label. Also performs reverse lookup
 			//		to set the hidden value.  label should corresponding to item.searchAttr.
-
-			if(label == null){ label = ''; }
+			
+			if(label === null){ // clear 
+				this.textbox.value = null;
+				this.valueNode.value = null;
+				this._lastDisplayedValue = "";
+				this._lastQuery = null;
+				return;
+			}
 
 			// This is called at initialization along with every custom setter.
 			// Usually (or always?) the call can be ignored.   If it needs to be


### PR DESCRIPTION
This makes difference between empty string and null as value. Before this fix FilteringSelect performs queries to backend store with empty string. This is not case when value is empty string. In that case, as and before, FilteringSelect performs query with wildcard.