### PR TITLE
Fixes DTK ticket 15134: calling get value before the iframe is loaded

### DIFF
--- a/_editor/RichText.js
+++ b/_editor/RichText.js
@@ -362,7 +362,6 @@ define([
 				// relying on the initial content being contained within the target
 				// domNode.
 				html = this.value;
-				delete this.value;
 				dn.innerHTML = "";
 			}else if(dn.nodeName && dn.nodeName.toLowerCase() == "textarea"){
 				// if we were created from a textarea, then we need to create a
@@ -1521,7 +1520,7 @@ define([
 				}
 			}
 
-			return this.isLoaded ? this._postFilterContent(null, nonDestructive) : '';
+			return this.isLoaded ? this._postFilterContent(null, nonDestructive) : this.value;
 		},
 		_getValueAttr: function(){
 			// summary:

--- a/tests/editor/Editor.html
+++ b/tests/editor/Editor.html
@@ -13,8 +13,9 @@
 			"dijit/registry",
 			"dijit/tests/helpers",
 			"dijit/Editor",
+			"dijit/form/Form",
 			"dojo/domReady!"
-		], function(doh, parser, registry, helpers){
+		], function(doh, parser, registry, helpers, Editor){
 
 			doh.register("setup", [
 				{
@@ -22,6 +23,8 @@
 					timeout: 5000,
 					runTest: function(){
 						parser.parse();
+						// In some browsers, the editor will not yet be loaded.  Testing that no error occurs
+						// when retrieving the value.
 						doh.is("", editor.get("value"));
 					}
 				},
@@ -40,6 +43,44 @@
 						editor.set("value", "hello");
 						editor.focus();
 						doh.is("hello", editor.editNode.textContent || editor.editNode.innerText);
+						doh.is("hello", editor.get("value"));
+					}
+				},
+				{
+					name: "initial value of unloaded editor",
+					timeout: 10000,
+					runTest: function(){
+						var tmpEditor = new Editor({});
+						doh.t(tmpEditor.get("value") == null);
+						doh.f(tmpEditor.isLoaded);
+					}
+				},
+				{
+					name: "initial value of unloaded editor",
+					timeout: 10000,
+					runTest: function(){
+						var tmpEditor = new Editor({});
+						doh.t(tmpEditor.get("value") == null);
+						doh.t(tmpEditor.value == null);
+						doh.f(tmpEditor.isLoaded);
+						tmpEditor.startup();
+						doh.is("", tmpEditor.get("value"));
+						doh.is("", tmpEditor.value);
+						doh.f(tmpEditor.isLoaded);
+					}
+				},
+				{
+					name: "get value of unloaded editor",
+					timeout: 10000,
+					runTest: function(){
+						var tmpEditor = new Editor({ value: "test editor value"});
+						doh.is("test editor value", tmpEditor.get("value"));
+						doh.is("test editor value", tmpEditor.value);
+						doh.f(tmpEditor.isLoaded);
+						tmpEditor.startup();
+						doh.is("test editor value", tmpEditor.get("value"));
+						doh.is("test editor value", tmpEditor.value);
+						doh.f(tmpEditor.isLoaded);
 					}
 				}
 			]);


### PR DESCRIPTION
Added an isLoaded check to RichText#getValue to avoid errors when the iframe has not yet loaded.

https://bugs.dojotoolkit.org/ticket/15134
