### PR TITLE
it is not possible to set value to null by clearing the input field

### DIFF
--- a/form/FilteringSelect.js
+++ b/form/FilteringSelect.js
@@ -74,7 +74,7 @@ define([
 			if((query && query[this.searchAttr] !== this._lastQuery) || (!query && result.length && this.store.getIdentity(result[0]) != this._lastQuery)){
 				return;
 			}
-			if(!result.length){
+			if(!result.length || result.length>1){
 				//#3268: don't modify display value on bad input
 				//#3285: change CSS to indicate error
 				this.set("value", '', priorityChange || (priorityChange === undefined && !this.focused), this.textbox.value, null);


### PR DESCRIPTION
When entering an empty string the value is set to the first element of all elements returned by the store.
The same happen if you call set("value",null).
The reason is that the label associated with the empty string is retrieved by issuing the "*" query, which
is matched by all items. I modified the callback in such a way that a result of more than one element
will set the value to null. A better solution would surely be to prevent the lookup completely if the input was an empty string.
