### PR TITLE
TextBox: make ctrl-shift change widget text direction (safari)

### DIFF
--- a/form/_TextBoxMixin.js
+++ b/form/_TextBoxMixin.js
@@ -227,6 +227,11 @@ define([
 
 			this.inherited(arguments);
 
+			//Bidi Support
+			// isCtrlKeyDown: Boolean
+			//	Used to handle Ctrl + Shift shortcut used to change the widget orientation
+			var isCtrlKeyDown = false;
+			
 			// normalize input events to reduce spurious event processing
 			//	onkeydown: do not forward modifier keys
 			//		       set charOrCode to numeric keycode
@@ -237,15 +242,28 @@ define([
 				var charOrCode;
 				if(e.type == "keydown"){
 					charOrCode = e.keyCode;
+					// Bidi Support
 					switch(charOrCode){ // ignore state keys
-						case keys.SHIFT:
 						case keys.ALT:
-						case keys.CTRL:
 						case keys.META:
 						case keys.CAPS_LOCK:
 						case keys.NUM_LOCK:
-						case keys.SCROLL_LOCK:
+						case keys.SCROLL_LOCK:{
+								isCtrlKeyDown = false;
 							return;
+					}
+						case keys.CTRL:{
+							isCtrlKeyDown  = true;
+							return;
+						}
+						case keys.SHIFT:{
+							if(isCtrlKeyDown  && has("safari")){
+								this.domNode.dir = (this.isLeftToRight()) ? "rtl" : "ltr";
+								this.dir = this.domNode.dir;
+								isCtrlKeyDown = false;
+						}
+						return;
+						}
 					}
 					if(!e.ctrlKey && !e.metaKey && !e.altKey){ // no modifiers
 						switch(charOrCode){ // ignore location keys


### PR DESCRIPTION
Make ctrl-shift change widget text direction (safari).

https://bugs.dojotoolkit.org/ticket/17721