### PR TITLE
Tree: don't expand drop target when dropping below the drop target

### DIFF
--- a/tree/dndSource.js
+++ b/tree/dndSource.js
@@ -471,7 +471,9 @@ define([
 
 				// Expand the target node (if it's currently collapsed) so the user can see
 				// where their node was dropped.   In particular since that node is still selected.
-				if(doExpand) this.tree._expandNode(target);
+				if(doExpand) {
+					this.tree._expandNode(target);
+				}
 			}
 			this.onDndCancel();
 		},


### PR DESCRIPTION
Don't expand drop target when dropping below the drop target, instead of onto the drop target.

For https://bugs.dojotoolkit.org/ticket/17977.
