### PR TITLE
#17990 Dijit menu positioning fix

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -112,11 +112,11 @@ define([
 					this._firstAroundPosition = newPos;
 					for(var i = 0; i < this._stack.length; i++){
 						var style = this._stack[i].wrapper.style;
-						style.top = (parseInt(style.top, 10) + dy) + "px";
+						style.top = (parseFloat(style.top, 10) + dy) + "px";
 						if(style.right == "auto"){
-							style.left = (parseInt(style.left, 10) + dx) + "px";
+							style.left = (parseFloat(style.left, 10) + dx) + "px";
 						}else{
-							style.right = (parseInt(style.right, 10) - dx) + "px";
+							style.right = (parseFloat(style.right, 10) - dx) + "px";
 						}
 					}
 				}


### PR DESCRIPTION
In popup._repositionAll(), CSS position properties are treated as floats instead of ints, preventing small positioning inconsistencies when the anchor element position changes when the user is zoomed in.
