### PR TITLE
#18086 RichText editor event tear down fix

### DIFF
--- a/_editor/RichText.js
+++ b/_editor/RichText.js
@@ -815,16 +815,11 @@ define([
 
 			var events = this.events.concat(this.captureEvents);
 			var ap = this.iframe ? this.document : this.editNode;
-			this.own(
+			this.own.apply(this,
 				array.map(events, function(item){
 					var type = item.toLowerCase().replace(/^on/, "");
-					on(ap, type, lang.hitch(this, item));
+					return on(ap, type, lang.hitch(this, item));
 				}, this)
-			);
-
-			this.own(
-				// mouseup in the margin does not generate an onclick event
-				on(ap, "mouseup", lang.hitch(this, "onClick"))
 			);
 
 			if(has("ie")){ // IE contentEditable

--- a/tests/editor/Editor.html
+++ b/tests/editor/Editor.html
@@ -94,6 +94,26 @@
 				}
 			]);
 
+			doh.register("destroy", [
+				{
+					name: "destroy the editor",
+					runTest: function(){
+						var d = new doh.Deferred();
+						var error = false;
+						try {
+							editor.destroyRecursive();
+						} catch(e){
+							error = e;
+						}
+
+						setTimeout(d.getTestCallback(function(){
+							doh.assertFalse(error);
+						}), 500);
+						return d;
+					}
+				}
+			]);
+
 			doh.run();
 		});
 	</script>


### PR DESCRIPTION
Event handles generated in the onLoad function of RichText were not being 'owned' properly. I updated the mapper to return a list of handles instead of undefineds and created a handle passed to own that would call remove on each of the event handles

Added test to show RichText is no longer throwing errors when being destroyed

https://bugs.dojotoolkit.org/ticket/18086
