### PR TITLE
Allow specifying the start and end of the visible range in the picker.

### DIFF
--- a/tests/_TimePicker.html
+++ b/tests/_TimePicker.html
@@ -37,6 +37,14 @@
 
 					tp.set('value', new Date());
 					doh.is(24, tp.timeMenu.children.length, 'Increment constraints should be copied but other non-constraint properties should not');
+				},
+				function min_max(){
+					var tp = _TimePicker({
+						pickerMin: "T09:00:00",
+						clickableIncrement: "T01:00:00",
+						pickerMax: "T17:00:00"
+					});
+					doh.is(9, tp.timeMenu.children.length, 'num entries');
 				}
 			]);
 

--- a/tests/form/robot/TimeTextBox.html
+++ b/tests/form/robot/TimeTextBox.html
@@ -456,6 +456,31 @@
 					}
 				]);
 
+				doh.register("limited drop down range", {
+					name: "9 to 5",
+					timeout: 10000,
+					runTest: function(){
+						var d = new doh.Deferred();
+
+						w = dijit.byId('q22');
+
+						// open drop down
+						w.focus();
+						doh.robot.keyPress(dojo.keys.DOWN_ARROW, 1000, {});
+						doh.robot.sequence(d.getTestCallback(function(){
+							var popup = dijit.byId('q22_popup');
+							doh.t(isVisible(popup), "popup visible");
+							doh.is(9, popup.containerNode.children.length, "# of entries in drop down")
+						}), 500);
+
+						return d;
+					},
+					tearDown: function(){
+						// Even if test failed, make sure drop down is closed so it doesn't interfere w/next test
+						w.closeDropDown();
+					}
+				});
+
 				doh.run();
 			});
 		</script>

--- a/tests/form/test_TimeTextBox.html
+++ b/tests/form/test_TimeTextBox.html
@@ -42,15 +42,7 @@
 		<script type="text/javascript" src="../_testCommon.js"></script>
 
 		<script type="text/javascript">
-			dojo.require("dijit.dijit"); // optimize: load dijit layer
-			dojo.require("dijit.form.TextBox");
-			dojo.require("dijit.form.ValidationTextBox");
-			dojo.require("dijit.form.NumberTextBox");
-			dojo.require("dijit.form.CurrencyTextBox");
-			dojo.require("dijit.form.DateTextBox");
 			dojo.require("dijit.form.TimeTextBox");
-			dojo.require("dojo.currency");
-			dojo.require("dojo.date.locale");
 			dojo.require("dojo.parser");	// scan page for widgets and instantiate them
 
 			formValue = null;
@@ -182,6 +174,31 @@
 					}, "q21").startup();
 			  });
 				</script>
+			</div>
+			<div class="dojoTitlePaneLabel">
+				<label for="q22">TimeTextBox with dropdown from 9AM - 5PM</label>
+				<span class="noticeMessage">TimeTextBox class,
+					Attributes: {formatLength:"medium",
+						pickerMin: "T09:00:00",
+						clickableIncrement: "T01:00:00",
+						pickerMax: "T17:00:00"}</span>
+			</div>
+			<div class="testExample">
+				<input id="q22" data-dojo-type="dijit/form/TimeTextBox"
+					data-dojo-props='
+					type:"text",
+					name:"time22",
+					value:"T9:45:00",
+					constraints:{
+						formatLength:"medium",
+						pickerMin: "T09:00:00",
+						clickableIncrement: "T01:00:00",
+						pickerMax: "T17:00:00"
+					},
+					required:true,
+					onChange:function(val){ dojo.byId("oc22").value = val; },
+					invalidMessage:"Invalid time." '/>
+				<label for="oc22">onChange:</label><input id="oc22" size="34" disabled value="not fired yet!" autocomplete="off"/>
 			</div>
 		</form>
 		<input id="ro" type="button" onclick="dijit.byId('q20').set('readOnly',true);" value="Set readOnly" tabIndex="-1"/>


### PR DESCRIPTION
Adds new pickerMin and pickerMax properties to _TimePicker, which can
be set indirectly through the TimeTextBox via the constraints property.
The old TimePicker had a `visibleRange` property but that doesn't really make sense anymore since we've changed how scrolling and sizing works.

Also a lot of general cleanup of comments etc.

Based partly on original patch from Joerg Sonnenberger, thanks!

Fixes [#18200](https://bugs.dojotoolkit.org/ticket/18200).

Supercedes PR #60.
