### PR TITLE
Tree: allow numeric ids (instead of string ids) in set("path", ...)

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -1037,7 +1037,7 @@ define([
 				return all(array.map(paths, function(path){
 					// normalize path to use identity
 					path = array.map(path, function(item){
-						return lang.isObject(item) ? tree.model.getIdentity(item) : item;
+						return item && lang.isObject(item) ? tree.model.getIdentity(item) : item;
 					});
 
 					if(path.length){


### PR DESCRIPTION
ID may be number.

See https://bugs.dojotoolkit.org/ticket/18279
