### PR TITLE
FontChoice plugin - add fix for Firefox

### DIFF
--- a/_editor/plugins/FontChoice.js
+++ b/_editor/plugins/FontChoice.js
@@ -535,7 +535,7 @@ define([
 				}
 
 				// strip off single quotes, if any
-				var quoted = lang.isString(value) && value.match(/'([^']*)'/);
+				var quoted = lang.isString(value) && (value.match(/'([^']*)'/) || value.match(/"([^"]*)"/));
 				if(quoted){
 					value = quoted[1];
 				}


### PR DESCRIPTION
Firefox seems to wrap the font name with doublequotes, preventing it
form being properly selected. Fixes:[#18387](https://bugs.dojotoolkit.org/ticket/18387)
