### PR TITLE
remove unused dependency - nlsLoading

### DIFF
--- a/layout/ContentPane.js
+++ b/layout/ContentPane.js
@@ -14,7 +14,8 @@ define([
 	"dojo/dom-construct", // empty()
 	"dojo/_base/xhr", // xhr.get
 	"dojo/i18n", // i18n.getLocalization
-	"dojo/when"
+	"dojo/when",
+	"dojo/i18n!../nls/loading"
 ], function(kernel, lang, _Widget, _Container, _ContentPaneResizeMixin, string, html, array, declare,
 			Deferred, dom, domAttr, domConstruct, xhr, i18n, when){
 


### PR DESCRIPTION
../nls/loading is being brought in using the i18n plugin but never being used. It looks like `i18n.getLocalization` is used to load the nls bundle instead to allow for the `lang` property to be used to determine the proper locale to load.
