### PR TITLE
#18262 updated Tundra theme to act like Claro

### DIFF
--- a/themes/tundra/Menu.css
+++ b/themes/tundra/Menu.css
@@ -6,6 +6,12 @@
 	background-color: #f7f7f7;
 }
 
+.tundra .dijitMenuTable {
+  border-collapse: separate;
+  border-spacing: 0 0;
+  padding: 0;
+}
+
 .tundra .dijitBorderContainer .dijitMenuBar {
 	border:1px solid #ccc;
 }


### PR DESCRIPTION
A right click followed by an immediate left click no longer causes the first menu item to fire.
Makes Tundra consistent with Claro and other themes.
