### PR TITLE
Fixes TextBox placeholder issue https://bugs.dojotoolkit.org/ticket/18396

### DIFF
--- a/form/TextBox.js
+++ b/form/TextBox.js
@@ -59,6 +59,10 @@ define([
 					 shown, s.fontFamily would trigger "Invalid Argument" error.*/}
 				});
 			}
+
+			this.own(
+				on(this.textbox, 'input', lang.hitch(this, '_updatePlaceHolder'))
+			);
 		},
 
 		_setPlaceHolderAttr: function(v){


### PR DESCRIPTION
Mobile Safari on iOS8 isn't updating the TextBox's value in the same cycle as the captured keypress event.  As a result this is happening:

1. keypress/keydown is captured and handled https://github.com/dojo/dijit/blob/master/form/_TextBoxMixin.js#L351-L353
1. the call to `_onInput` is deferred https://github.com/dojo/dijit/blob/master/form/_TextBoxMixin.js#L351-L353
1. _onInput is called in the next cycle
1. iOS updates TextBox#value and fires the input event
1. The handling of the input event is skipped https://github.com/dojo/dijit/blob/master/form/_TextBoxMixin.js#L313-L320

I don't think attaching the onInput handler to just any input event is the right way to go.  If there is not a good reason for doing this, for instance historical support for browsers or for efficiency, then we should consider splitting the handlers for input and keydown/keypress as the most straightforward solution.

Refs: https://bugs.dojotoolkit.org/ticket/18396