### PR TITLE
DateTextBox: make sure that `this.value` is always a `dateClassObj`

### DIFF
--- a/tests/form/test_DateTextBox.html
+++ b/tests/form/test_DateTextBox.html
@@ -216,7 +216,7 @@
 						function noInitialValue(){
 							var fromDate = registry.byId('fromDate');
 							doh.is('', fromDate.get('displayedValue'), 'initially blank');
-							doh.is(DateTextBox.prototype.value, fromDate.value, 'default value');
+							doh.is(new Date('').toString(), fromDate.value.toString(), 'default value');
 							var d = new doh.Deferred();
 							var today = new Date();
 							fromDate.set('value', today, true);


### PR DESCRIPTION
Fixes [#18394](https://bugs.dojotoolkit.org/ticket/18394), a problem with hebrew calendars.
Unfortunately I don't have an automated test case since it requires code
in dojox/date to test.

Refs [#5074](https://bugs.dojotoolkit.org/ticket/5074) (the support for specifying non-gregorian calendars), and
refs [#11251](https://bugs.dojotoolkit.org/ticket/11251) (which is when the custom `_set()` method was added that calls `compare()`).
