### PR TITLE
Embedded Forms in IE8 support

### DIFF
--- a/form/Form.js
+++ b/form/Form.js
@@ -57,7 +57,7 @@ define([
 		//		Target frame for the document to be opened in.
 		target: "",
 
-		templateString: "<form data-dojo-attach-point='containerNode' data-dojo-attach-event='onreset:_onReset,onsubmit:_onSubmit' ${!nameAttrSetting}></form>",
+		templateString: "<div data-dojo-attach-point='containerNode' data-dojo-attach-event='onreset:_onReset,onsubmit:_onSubmit' ${!nameAttrSetting}></div>",
 
 		postMixInProperties: function(){
 			// Setup name=foo string to be referenced from the template (but only if a name has been specified)

--- a/form/Form.js
+++ b/form/Form.js
@@ -57,11 +57,11 @@ define([
 		//		Target frame for the document to be opened in.
 		target: "",
 
-		// accept : Boolean
-		//		Whether to change the markup to allow embedded forms (in forms) for IE 8
-		embedded : false,
+		// accept : String
+		//		The HTML tag the form should reside in.
+		rootTag : 'form',
 
-		templateString: "<" + this._formOrDiv() " data-dojo-attach-point='containerNode' data-dojo-attach-event='onreset:_onReset,onsubmit:_onSubmit' ${!nameAttrSetting}></" + this._formOrDiv() + ">",
+		templateString: "<${rootTag} data-dojo-attach-point='containerNode' data-dojo-attach-event='onreset:_onReset,onsubmit:_onSubmit' ${!nameAttrSetting}></${rootTag}>",
 
 		postMixInProperties: function(){
 			// Setup name=foo string to be referenced from the template (but only if a name has been specified)
@@ -167,10 +167,7 @@ define([
 			if(!(this.onSubmit() === false)){
 				this.containerNode.submit();
 			}
-		},
-
-		_formOrDiv : function () {
-			return this.embedded ? "div" : "form";
 		}
+
 	});
 });

--- a/form/Form.js
+++ b/form/Form.js
@@ -57,7 +57,11 @@ define([
 		//		Target frame for the document to be opened in.
 		target: "",
 
-		templateString: "<div data-dojo-attach-point='containerNode' data-dojo-attach-event='onreset:_onReset,onsubmit:_onSubmit' ${!nameAttrSetting}></div>",
+		// accept : Boolean
+		//		Whether to change the markup to allow embedded forms (in forms) for IE 8
+		embedded : false,
+
+		templateString: "<" + this._formOrDiv() " data-dojo-attach-point='containerNode' data-dojo-attach-event='onreset:_onReset,onsubmit:_onSubmit' ${!nameAttrSetting}></" + this._formOrDiv() + ">",
 
 		postMixInProperties: function(){
 			// Setup name=foo string to be referenced from the template (but only if a name has been specified)
@@ -163,6 +167,10 @@ define([
 			if(!(this.onSubmit() === false)){
 				this.containerNode.submit();
 			}
+		},
+
+		_formOrDiv : function () {
+			return this.embedded ? "div" : "form";
 		}
 	});
 });


### PR DESCRIPTION
Due to a mad bug in IE 8, you can't embed a Form within a Form without throwing a 'unknown runtime error'. To fix this, I changed the tempate markup slightly - all other functionality remains with only a small change in semantic markup.

If you'd like this instead as a flag or method, just let me know and I'll update the PR. Hope this helps!