### PR TITLE
[cla] Fix incorrect ``this`` for query error handler.

### DIFF
--- a/form/_FormSelectWidget.js
+++ b/form/_FormSelectWidget.js
@@ -408,10 +408,10 @@ define([
 					}
 					this.onLoadDeferred.resolve(true);
 					this.onSetStore();
-				}), function(err){
+				}), lang.hitch(this, function(err){
 					console.error('dijit.form.Select: ' + err.toString());
 					this.onLoadDeferred.reject(err);
-				});
+				}));
 			}
 			return oStore;	// dojo/data/api/Identity
 		},


### PR DESCRIPTION
``dijit/form/_FormSelectWidget`` does not properly set the ``this`` scope for its query error handler. This prevents the ``onLoadDeferred`` from properly getting rejected.

As far as I can tell, this issue doesn't visibly break anything in dijit, as I could not find any callbacks for an ``onLoadDeferred`` error case.