### PR TITLE
Resolve iOS8 bug where keystrokes processing one keystroke late

### DIFF
--- a/form/_TextBoxMixin.js
+++ b/form/_TextBoxMixin.js
@@ -346,11 +346,11 @@ define([
 					return;
 				} // if preventDefault was called
 
-				// Ideally we would just call _onInput() on the "input" event, as done below.
-				// But that event isn't supported fully on <= IE9.  The this.defer() call is a workaround.
+				// IE8 doesn't emit the "input" event at all, and IE9 doesn't emit it for backspace, delete, cut, etc.
+				// Since the code below (and perhaps user code) depends on that event, emit it synthetically.
 				// See http://benalpert.com/2013/06/18/a-near-perfect-oninput-shim-for-ie-8-and-9.html.
-				// We could add code to debounce notifications, but it doesn't seem strictly necessary.
-				if(has("ie") <= 8 || (has("ie") == 9 && e.keyCode == keys.BACKSPACE)){
+				// I could add code to debounce and remove duplicate notifications, but it doesn't seem strictly necessary.
+				if(has("ie") <= 9){
 					this.defer(function(){
 						on.emit(this.textbox, "input", {bubbles: true});
 					});

--- a/tests/_BidiSupport/form/test_TimeTextBox.html
+++ b/tests/_BidiSupport/form/test_TimeTextBox.html
@@ -24,13 +24,13 @@
 			});
 
 			function testWidget(element, guiDir, textDir, isfirstChildLatin){
-				doh.is(registry.byId(element).get("textDir"), textDir, "widget textDir");
-				doh.is(registry.byId(element).dir, guiDir, "GUI dir");
+				doh.is(textDir, registry.byId(element).get("textDir"), "widget textDir");
+				doh.is(guiDir, registry.byId(element).dir.toLowerCase(), "GUI dir");
 				doh.is(guiDir.toLowerCase() == "ltr", registry.byId(element).isLeftToRight(), "isLeftToRight()");
 				if(textDir == "auto"){
 					textDir = isfirstChildLatin? "ltr" : "rtl";
 				}
-				doh.is(registry.byId(element).focusNode.dir, textDir, "focusNode textDir");
+				doh.is(textDir, registry.byId(element).focusNode.dir, "focusNode textDir");
 				doh[guiDir.toLowerCase() == "rtl" ? "t" : "f"](domClass.contains(registry.byId(element).domNode, "dijitTimeTextBoxRtl"), "dijitTimeTextBoxRtl");
 			}
 
@@ -131,7 +131,7 @@
 				{
 					name:"textbox",
 					runTest:function(){
-						testWidget("q4", "LTR", "auto", false);
+						testWidget("q4", "ltr", "auto", false);
 					}
 				},
 				{
@@ -146,7 +146,7 @@
 				{
 					name:"textbox",
 					runTest:function(){
-						testWidget("q5", "RTL", "ltr", true);
+						testWidget("q5", "rtl", "ltr", true);
 					}
 				},
 				{

--- a/tests/editor/robot/Editor_IE8Compat.html
+++ b/tests/editor/robot/Editor_IE8Compat.html
@@ -49,7 +49,7 @@
 							robot.typeKeys("world", 500, 1650);
 
 							robot.sequence(d.getTestCallback(function(){
-								var val = editor1.get('value').replace(/ +/g, "").toLowerCase();
+								var val = editor1.get('value').replace(/[\s\xA0]+/g, "").toLowerCase();
 								doh.is("hello<br/>world", val);
 							}), 500);
 

--- a/tests/form/mobile.html
+++ b/tests/form/mobile.html
@@ -24,7 +24,7 @@
 				"dijit/form/CheckBox",
 				"dijit/form/RadioButton",
 
-				"dijit/form/NumberTextBox",
+				"dijit/form/ValidationTextBox",
 				"dijit/form/DateTextBox",
 				"dijit/form/TimeTextBox",
 				"dijit/form/NumberSpinner",
@@ -90,6 +90,8 @@
 		</fieldset>
 
 		<h1>TextBoxes</h1>
+		<label for="vtb">ValidationTextBox:</label>
+		<input id="vtb" data-dojo-type="dijit/form/ValidationTextBox" placeHolder="hint text">
 		<label for="q03">NumberSpinner:</label>
 		<input id="q03" data-dojo-type="dijit/form/NumberSpinner"
 			name="age" tabIndex="1" class="small"

--- a/tests/form/robot/Textarea.html
+++ b/tests/form/robot/Textarea.html
@@ -74,8 +74,7 @@
 								}), 1000);
 
 								// Test shrink on delete of newline
-								robot.keyPress(keys.LEFT_ARROW, 200, {});
-								robot.keyPress(keys.DELETE, 200, {});
+								robot.keyPress(keys.BACKSPACE, 200, {});
 								robot.sequence(d.getTestCallback(function(){
 									height3 = domGeom.getMarginBox(w.domNode).h;
 									doh.t(height2 > height1, "height ("+height2+") should have increased from " + height1);
@@ -115,14 +114,11 @@
 									} // still typing
 									height2 = domGeom.getMarginBox(w.domNode).h;
 									typing = false;
-									// Test shrink on delete (backspace) of text.   delete seems to delete the next character
-									// rather than the previous character, hence the LEFT_ARROW.
-									robot.keyPress(keys.LEFT_ARROW, 0, {});
-									robot.keyPress(keys.DELETE, 0, {});
+									// Test shrink on delete (backspace) of text
+									robot.keyPress(keys.BACKSPACE, 0, {});
 								}else{
 									if(nv.length > pos){
-										robot.keyPress(keys.LEFT_ARROW, 0, {});
-										robot.keyPress(keys.DELETE, 0, {});
+										robot.keyPress(keys.BACKSPACE, 0, {});
 										return; // still deleting
 									}
 									handler.remove();
@@ -157,6 +153,7 @@
 							robot.keyPress("x", 500, modifier);
 							robot.sequence(function(){
 								height2 = domGeom.getMarginBox(w.domNode).h;
+								doh.t(height2 < height1, "height2 (" + height2 + ") < height1 (" + height1 + ")");
 							}, 500);
 
 							// Paste text, height should increase
@@ -164,8 +161,7 @@
 							robot.keyPress("v", 500, modifier);
 							robot.sequence(d.getTestCallback(function(){
 								height3 = domGeom.getMarginBox(w.domNode).h;
-								doh.t(height2 < height1, "height went from " + height1 + " to " + height2);
-								doh.t(height3 > height2, "height went from " + height2 + " to " + height3);
+								doh.t(height3 > height2, "height3 (" + height3 + ") > height2 (" + height2 + ")");
 							}), 500);
 
 							return d;
@@ -193,8 +189,7 @@
 								}, 500);
 
 								// Erase a character
-								robot.keyPress(keys.LEFT_ARROW, 100, {});
-								robot.keyPress(keys.DELETE, 500, {});
+								robot.keyPress(keys.BACKSPACE, 500, {});
 								robot.sequence(function(){
 									value2 = ta.get("value");
 								}, 500);

--- a/tests/form/test_Textarea.html
+++ b/tests/form/test_Textarea.html
@@ -53,6 +53,10 @@
 	</head>
 	<body role="main">
 
+		<script type="dojo/require">
+			dom: "dojo/dom"
+		</script>
+
 		<h1 class="testTitle">Auto-sizing Textarea Widget Test</h1>
 
 		<!--    to test form submission, you'll need to create an action handler similar to
@@ -66,7 +70,7 @@
 
 			<label for="simple">dijit.form.Textarea, inline with maxLength=50:</label>
 			<textarea id="simple" data-dojo-type="dijit/form/Textarea" data-dojo-props='name:"simpleTextArea", maxLength:"50", style:{width:"33%"},
-	         		onChange:function(val){ dojo.byId("ocSimple").value = val; },
+	         		onChange:function(val){ dom.byId("ocSimple").value = val; },
 	         		onFocus:function(){ console.log("user focus handler"); },
 	         		onBlur:function(){ console.log("user blur handler"); }
 				'>this is a very simple resizable text area</textarea>


### PR DESCRIPTION
Resolve iOS8 bug where placeHolder text wasn't hidden until the second characterand also problem where ValidationTextBox's error state was updated one keystroke late.

Root cause was that _onInput() was being called before this.textbox.value was updated,
because on iOS8 an `<input>`'s value takes a while to be updated (longer than a 0ms timeout).
So, switched the code to call _onInput() based on the "input" event, with workaround code for IE8 and IE9.

Fixes https://bugs.dojotoolkit.org/ticket/18396, https://bugs.dojotoolkit.org/ticket/18501.

This diff is somewhat hard to follow given TextBoxMixin's poorly named functions:

* _onInput() is called after the "input" event, i.e. after the `<input>`'s value has been updated
* onInput() is called on keypress, keydown, etc., before the `<input>`'s value has been updated

I'm also unclear when/if there would ever be an "input" event that wasn't preceded by some other event.   Even for cut/paste with the mouse there should be cut/paste events.