### PR TITLE
fixes #18467. Cut/Copy/Paste in Editor Widget on Firefox no longer givin...

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -419,18 +419,15 @@ define([
 				// Try to exec the superclass exec-command and see if it works.
 				r = this.document.execCommand(cmd, false, null);
 				if(has("webkit") && !r){ //see #4598: webkit does not guarantee clipboard support from js
-					throw { code: 1011 }; // throw an object like Mozilla's error
+					throw {}; // throw to show the warning
 				}
 			}catch(e){
-				//TODO: when else might we get an exception?  Do we need the Mozilla test below?
-				if(e.code == 1011 /* Mozilla: service denied */ ||
-					(e.code == 9 && has("opera") /* Opera not supported */)){
-					// Warn user of platform limitation.  Cannot programmatically access clipboard. See ticket #4136
-					var sub = string.substitute,
-						accel = {cut: 'X', copy: 'C', paste: 'V'};
-					alert(sub(this.commands.systemShortcut,
-						[this.commands[cmd], sub(this.commands[has("mac") ? 'appleKey' : 'ctrlKey'], [accel[cmd]])]));
-				}
+				//Ticket #18467 removed the checks to specific codes
+				// Warn user of platform limitation.  Cannot programmatically access clipboard. See ticket #4136
+				var sub = string.substitute,
+					accel = {cut: 'X', copy: 'C', paste: 'V'};
+				alert(sub(this.commands.systemShortcut,
+					[this.commands[cmd], sub(this.commands[has("mac") ? 'appleKey' : 'ctrlKey'], [accel[cmd]])]));
 				r = false;
 			}
 			return r;


### PR DESCRIPTION
...g the message to use the keyboard. FF changed the code being used in the exception, updated the editor code to no longer depend upon the exception code.