### PR TITLE
Remove role=presentation from hidden <input> nodes in button widgets.

### DIFF
--- a/form/templates/Button.html
+++ b/form/templates/Button.html
@@ -14,5 +14,5 @@
 	></span
 	><input ${!nameAttrSetting} type="${type}" value="${value}" class="dijitOffScreen"
 		data-dojo-attach-event="onclick:_onClick"
-		tabIndex="-1" role="presentation" aria-hidden="true" data-dojo-attach-point="valueNode"
+		tabIndex="-1" aria-hidden="true" data-dojo-attach-point="valueNode"
 /></span>

--- a/form/templates/ComboButton.html
+++ b/form/templates/ComboButton.html
@@ -19,8 +19,6 @@
 		></td
 		><td style="display:none !important;"
 			><input ${!nameAttrSetting} type="${type}" value="${value}" data-dojo-attach-point="valueNode"
-				class="dijitOffScreen"
-				role="presentation" aria-hidden="true"
-				data-dojo-attach-event="onclick:_onClick"
+				class="dijitOffScreen" aria-hidden="true" data-dojo-attach-event="onclick:_onClick"
 		/></td></tr></tbody
 ></table>

--- a/form/templates/DropDownButton.html
+++ b/form/templates/DropDownButton.html
@@ -16,6 +16,5 @@
 		></span
 	></span
 	><input ${!nameAttrSetting} type="${type}" value="${value}" class="dijitOffScreen" tabIndex="-1"
-		data-dojo-attach-event="onclick:_onClick"
-		data-dojo-attach-point="valueNode" role="presentation" aria-hidden="true"
+		data-dojo-attach-event="onclick:_onClick" data-dojo-attach-point="valueNode" aria-hidden="true"
 /></span>


### PR DESCRIPTION
It's unnecessary for JAWS and violates the new ARIA spec for <input type=button>
at http://www.w3.org/TR/html5/dom.html#sec-implicit-aria-semantics.
Fixes #18547.

cc @mbillau (if that's the same Mike Billau that wrote https://bugs.dojotoolkit.org/ticket/18547)