### PR TITLE
#18579 dijit/form/HorizontalSlider _bumpValue imprecise

### DIFF
--- a/form/HorizontalSlider.js
+++ b/form/HorizontalSlider.js
@@ -254,7 +254,8 @@ define([
 				count = c[this._pixelCount];
 			}
 			count--;
-			var value = (this.value - this.minimum) * count / (this.maximum - this.minimum) + signedChange;
+                    //the division is imprecise so the expression has to be rounded to avoid long floating numbers
+			var value = Math.round((this.value - this.minimum) * count / (this.maximum - this.minimum)) + signedChange;
 			if(value < 0){
 				value = 0;
 			}


### PR DESCRIPTION
Using bump action (the increment/decrement buttons or keyboard arrows) results in floating values slightly off the expected value, resulting in really annoying long floating numbers with 15 digits after decimal point.
Strategically placed Math.round() fixes this behaviour.