### PR TITLE
Backport "Move popup (or stack of popups) when the aroundNode is moved." to 1.8 branch

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -94,6 +94,32 @@ define([
 
 		_idGen: 1,
 
+		_repositionAll: function(){
+			// summary:
+			//		If screen has been scrolled, reposition all the popups in the stack.
+			//		Then set timer to check again later.
+
+			var oldPos = this._firstAroundPosition,
+				newPos = domGeometry.position(this._firstAroundNode, true),
+				dx = newPos.x - oldPos.x,
+				dy = newPos.y - oldPos.y;
+
+			if(dx || dy){
+				this._firstAroundPosition = newPos;
+				for(var i = 0; i < this._stack.length; i++){
+					var style = this._stack[i].wrapper.style;
+					style.top = (parseInt(style.top, 10) + dy) + "px";
+					if(style.right == "auto"){
+						style.left = (parseInt(style.left, 10) + dx) + "px";
+					}else{
+						style.right = (parseInt(style.right, 10) - dx) + "px";
+					}
+				}
+			}
+
+			this._aroundMoveListener = setTimeout(lang.hitch(this, "_repositionAll"), dx || dy ? 10 : 50);
+		},
+
 		_createWrapper: function(/*Widget*/ widget){
 			// summary:
 			//		Initialization for widgets that will be used as popups.
@@ -214,7 +240,14 @@ define([
 				dijitPopupParent: args.parent ? args.parent.id : ""
 			});
 
-			if(has("bgIframe") && !widget.bgIframe){
+			if(stack.length == 0 && around){
+				// First element on stack. Save position of aroundNode and setup listener for changes to that position.
+				this._firstAroundNode = around;
+				this._firstAroundPosition = domGeometry.position(around, true);
+				this._aroundMoveListener = setTimeout(lang.hitch(this, "_repositionAll"), 50);
+			}
+
+			if(has("config-bgIframe") && !widget.bgIframe){
 				// setting widget.bgIframe triggers cleanup in _Widget.destroy()
 				widget.bgIframe = new BackgroundIframe(wrapper);
 			}
@@ -260,6 +293,7 @@ define([
 
 			stack.push({
 				widget: widget,
+				wrapper: wrapper,
 				parent: args.parent,
 				onExecute: args.onExecute,
 				onCancel: args.onCancel,
@@ -309,6 +343,11 @@ define([
 				if(onClose){
 					onClose();
 				}
+			}
+
+			if(stack.length == 0 && this._aroundMoveListener){
+				clearTimeout(this._aroundMoveListener);
+				this._firstAroundNode = this._firstAroundPosition = this._aroundMoveListener = null;
 			}
 		}
 	});

--- a/tests/popup.html
+++ b/tests/popup.html
@@ -474,7 +474,11 @@
 <body>
 	<h1>popup and BackgroundIFrame Unit Test</h1>
 	<label for="inputAtStart">label:</label><input id="inputAtStart">
-	<span id="widgets"></span>
+	<div style="height: 150px; overflow: auto; margin: 10px 0px;">
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis cursus odio eu nisl ultrices dictum. Sed tincidunt metus et magna placerat eget vehicula dolor faucibus. Nunc nec augue ac mi rutrum congue. Donec at augue felis. Proin et lectus at mauris adipiscing pulvinar tempor vitae lacus. Aliquam erat volutpat. Sed eget sem eu turpis ultrices ullamcorper sed ut augue. Nunc in augue lectus. Curabitur ac posuere libero. Duis luctus dignissim nisl suscipit vehicula. Cras ut augue odio. Integer blandit ligula congue erat pellentesque nec egestas mi hendrerit</p>
+		<span id="widgets"></span>
+		<p>Nunc sollicitudin nisl sed est porta vitae viverra nulla rutrum. Praesent erat tortor, scelerisque sit amet gravida a, sodales a libero. Pellentesque nec arcu nulla, id laoreet orci. Vivamus sit amet quam eu ante pulvinar rhoncus sit amet non ipsum. Sed mattis felis sed risus tincidunt in sagittis justo rhoncus. Praesent ut justo feugiat neque gravida convallis eget mattis felis. Vestibulum vitae velit ante, sed convallis sem. Curabitur gravida volutpat odio eget tincidunt. Mauris pellentesque placerat massa ut venenatis. Mauris ultrices hendrerit dui vel fermentum.</p>
+	</div>
 	<label for="inputAtEnd">label:</label><input id="inputAtEnd">
 </body>
 </html>


### PR DESCRIPTION
Fixes #5777 on the 1.8 branch

This is a cherry-pick of f7e1c27065a0c3179fe8ec20f68eef11e035b7cb that fixes the issue where tooltip dialogs do not reposition after events such as `orientationchange` on the 1.8 branch.