### PR TITLE
Restore container dimension after double clicking splitter

### DIFF
--- a/layout/BorderContainer.js
+++ b/layout/BorderContainer.js
@@ -134,8 +134,18 @@ define([
 				layoutFunc = lang.hitch(this.container, "_layoutChildren", this.child.id),
 				de = this.ownerDocument;
 
+			var minLoad = min;
 			this._handlers = this._handlers.concat([
 				on(de, touch.move, this._drag = function(e, forceResize){
+				    // restore old size
+				    if (this.child && this.child.domNode.style[this.horizontal ? "height" : "width"] === "0px" && this.container && this.container.persist) {
+			            var persistSize = cookie(this._cookieName);
+			            if (persistSize) {
+			                min = persistSize.replace("px", "");
+				        }
+				    } else {
+				        min = minLoad;
+				    }
 					var delta = e[axis] - pageStart,
 						childSize = factor * delta + childStart,
 						boundChildSize = Math.max(Math.min(childSize, max), min);


### PR DESCRIPTION
https://bugs.dojotoolkit.org/ticket/18616
While double clicking splitter to hide/unhide subsequent bordercontainer, container would collapse properly but double clicking again on splitter would be not able to restore container to its initial dimension.