### PR TITLE
Hide Tooltip on mouseover

### DIFF
--- a/Tooltip.js
+++ b/Tooltip.js
@@ -491,7 +491,7 @@ define([
 
 					// Show tooltip and setup callbacks for mouseenter/mouseleave of tooltip itself
 					Tooltip.show(content, this._connectNode, this.position, !this.isLeftToRight(), this.textDir,
-						lang.hitch(this, "set", "state", SHOWING), lang.hitch(this, "set", "state", HIDE_TIMER));
+						lang.hitch(this, "set", "state", HIDE_TIMER), lang.hitch(this, "set", "state", HIDE_TIMER));
 
 					this.onShow(this._connectNode, this.position);
 					break;


### PR DESCRIPTION
1.10 introduced a change where the tooltip would not hide on mouseover.
Revert to previous behavior and hide the tooltip on mouseover.