### PR TITLE
fix event passed to _onInput() on android/chrome w/word suggestion

### DIFF
--- a/form/_TextBoxMixin.js
+++ b/form/_TextBoxMixin.js
@@ -208,14 +208,16 @@ define([
 			 //		callback
 		 },
 
-		_onInput: function(/*Event*/ /*===== evt =====*/){
+		_onInput: function(/*Event*/ evt){
 			// summary:
 			//		Called AFTER the input event has happened and this.textbox.value has new value.
 
 			this._lastInputEventValue = this.textbox.value;
 
-			// For Combobox, this needs to be called w/the keydown/keypress event that was passed to onInput()
-			this._processInput(this._lastInputProducingEvent);
+			// For Combobox, this needs to be called w/the keydown/keypress event that was passed to onInput().
+			// As a backup, use the "input" event itself.
+			this._processInput(this._lastInputProducingEvent || evt);
+			delete this._lastInputProducingEvent;
 
 			if(this.intermediateChanges){
 				this._handleOnChange(this.get('value'), false);
@@ -250,7 +252,10 @@ define([
 			//	paste, cut, compositionend: set charOrCode to 229 (IME)
 			function handleEvent(e){
 				var charOrCode;
-				if(e.type == "keydown"){
+
+				// Filter out keydown events that will be followed by keypress events.  Note that chrome/android
+				// w/word suggestion has keydown/229 events on typing with no corresponding keypress events.
+				if(e.type == "keydown" && e.keyCode != 229){
 					charOrCode = e.keyCode;
 					switch(charOrCode){ // ignore state keys
 						case keys.SHIFT:
@@ -297,6 +302,7 @@ define([
 						} // only allow named ones through
 					}
 				}
+
 				charOrCode = e.charCode >= 32 ? String.fromCharCode(e.charCode) : e.charCode;
 				if(!charOrCode){
 					charOrCode = (e.keyCode >= 65 && e.keyCode <= 90) || (e.keyCode >= 48 && e.keyCode <= 57) || e.keyCode == keys.SPACE ? String.fromCharCode(e.keyCode) : e.keyCode;


### PR DESCRIPTION
On [some] android phones typing printables produces keydown events but no corresponding keypress events.  Selecting something from the word suggestion list produces a compositionend event:

![wordsuggestion](https://cloud.githubusercontent.com/assets/69599/9536056/90df9612-4d62-11e5-801c-13defbbe2d2e.gif)

This seems like a bug in Chrome/android, but I guess we just need to work around it.

Fixes #18673.

@AdrianVasiliu, how does it look?

I also thought about ignoring the `type=keydown keycode=229` events completely and just relying on the compositionend event, but that only comes if you select a choice from the word suggestions, not if you just close the keyboard after typing (to use exactly what you typed rather than using an auto-completion suggestion).