### PR TITLE
Exclude node_modules from minified build, make copy only (#18648)

### DIFF
--- a/dijit.profile.js
+++ b/dijit.profile.js
@@ -1,5 +1,6 @@
 var profile = (function(){
 	var testResourceRe = /^dijit\/tests\//,
+	nodeModulesRe = /\/node_modules\//,
 
 		copyOnly = function(filename, mid){
 			var list = {
@@ -7,10 +8,10 @@ var profile = (function(){
 				"dijit/package.json":1,
 				"dijit/themes/claro/compile":1
 			};
-			return (mid in list) || (/^dijit\/resources\//.test(mid)
-				&& !/\.css$/.test(filename))
-				|| /(png|jpg|jpeg|gif|tiff)$/.test(filename)
-				|| /\/node_modules\//.test(mid);
+			return (mid in list) ||
+				(/^dijit\/resources\//.test(mid) && !/\.css$/.test(filename)) ||
+				/(png|jpg|jpeg|gif|tiff)$/.test(filename) ||
+				nodeModulesRe.test(mid);
 		};
 
 	return {
@@ -28,9 +29,9 @@ var profile = (function(){
 			},
 
 			miniExclude: function(filename, mid){
-				return /^dijit\/bench\//.test(mid)
-					|| /^dijit\/themes\/themeTest/.test(mid)
-					|| /\/node_modules\//.test(mid);
+				return /^dijit\/bench\//.test(mid) ||
+					/^dijit\/themes\/themeTest/.test(mid) ||
+					nodeModulesRe.test(mid);
 			}
 		}
 	};

--- a/dijit.profile.js
+++ b/dijit.profile.js
@@ -7,7 +7,10 @@ var profile = (function(){
 				"dijit/package.json":1,
 				"dijit/themes/claro/compile":1
 			};
-			return (mid in list) || (/^dijit\/resources\//.test(mid) && !/\.css$/.test(filename)) || /(png|jpg|jpeg|gif|tiff)$/.test(filename);
+			return (mid in list) || (/^dijit\/resources\//.test(mid)
+				&& !/\.css$/.test(filename))
+				|| /(png|jpg|jpeg|gif|tiff)$/.test(filename)
+				|| /\/node_modules\//.test(mid);
 		};
 
 	return {
@@ -25,11 +28,10 @@ var profile = (function(){
 			},
 
 			miniExclude: function(filename, mid){
-				return /^dijit\/bench\//.test(mid) || /^dijit\/themes\/themeTest/.test(mid);
+				return /^dijit\/bench\//.test(mid)
+					|| /^dijit\/themes\/themeTest/.test(mid)
+					|| /\/node_modules\//.test(mid);
 			}
 		}
 	};
 })();
-
-
-


### PR DESCRIPTION
While Dijit doesn't use any node_modules today, it seemed safest from a future proofing and consistency perspective to exclude from the build.