### PR TITLE
refs #18721, Select with 0 or 1 item does not throw errors while keybord navigation 

### DIFF
--- a/_KeyNavMixin.js
+++ b/_KeyNavMixin.js
@@ -386,7 +386,7 @@ define([
 							break;
 						}
 						currentItem = this._getNextFocusableChild(currentItem, 1);
-					}while(currentItem != stop);
+					}while(currentItem && currentItem != stop);
 					// commented out code block to search again if the multichar search fails after a smaller timeout
 					//if(!numMatches && (this._typingSlowly || searchLen == 1)){
 					//	this._searchString = '';

--- a/tests/_KeyNavContainer.html
+++ b/tests/_KeyNavContainer.html
@@ -192,8 +192,6 @@
 						// searach with no match
 						on.emit(c.domNode, "keypress", {charCode: 97 /* "a" */, bubbles: true, cancelable: true});
 											
-						window.onerror = d.reject;
-						
 						setTimeout(d.getTestCallback(function(){
 							doh.is("notFocusedChildContainer", focus.curNode.id, "focus not changed");
 						}), 0);

--- a/tests/_KeyNavContainer.html
+++ b/tests/_KeyNavContainer.html
@@ -30,6 +30,14 @@
 					this.domNode.focus();
 				}
 			});
+			
+			declare("TestNotFocusedChildContainer", [_WidgetBase, _KeyNavContainer], {
+				// Some container may override focus and have 'focusedChild==null'
+				// dijit/form/Select is a sample
+				focus: function(){
+					this.domNode.focus();
+				}
+			});
 
 			doh.register("parse", function(){
 				parser.parse();
@@ -144,6 +152,57 @@
 
 						return d;
 					}
+				},
+				{
+					name: "search (& match) in container with not focused child",
+					runTest: function(t){
+						var d = new doh.Deferred();
+
+						var c = registry.byId("notFocusedChildContainer");
+						c.focus();
+						
+						doh.is("notFocusedChildContainer", focus.curNode.id, "container is focused");
+						
+						// searach with no match
+						on.emit(c.domNode, "keypress", {charCode: 115 /* "s" */, bubbles: true, cancelable: true});
+												
+						setTimeout(d.getTestCallback(function(){
+							doh.is("single", focus.curNode.id, "focus changed to child 'single'");
+						}), 0);
+
+						return d;
+					}
+				},
+				{
+					name: "search (& no match) in container with not focused child",
+					setUp: function() {
+						var d = this.d = new doh.Deferred();
+						window.onerror = function(msg){
+							d.reject(new Error(msg));
+						};
+					},
+					runTest: function(t){
+						var d = this.d;
+
+						var c = registry.byId("notFocusedChildContainer");
+						c.focus();
+						
+						doh.is("notFocusedChildContainer", focus.curNode.id, "container is focused");
+						
+						// searach with no match
+						on.emit(c.domNode, "keypress", {charCode: 97 /* "a" */, bubbles: true, cancelable: true});
+											
+						window.onerror = d.reject;
+						
+						setTimeout(d.getTestCallback(function(){
+							doh.is("notFocusedChildContainer", focus.curNode.id, "focus not changed");
+						}), 0);
+
+						return d;
+					},
+					tearDown: function(){
+						window.onerror = null;
+					}
 				}
 			]);
 
@@ -159,8 +218,13 @@
 		<!-- comment just to make sure that numbering isn't thrown off -->
 		<div id="zero" data-dojo-type="TestContained">zero</div>
 		<div id="one" data-dojo-type="TestContained">one</div>
-		<div id="two" data-dojo-type="TestContained">two</div>
+		<div id="two" data-dojo-type="TestContained">two</div> 
 		<div id="three" data-dojo-type="TestContained">three</div>
+	</div>
+	
+	<div id="notFocusedChildContainer" data-dojo-type="TestNotFocusedChildContainer">
+		<!-- comment just to make sure that numbering isn't thrown off -->
+		<div id="single" data-dojo-type="TestContained">single</div>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
_KeyNavMixin._keyboardSearch now accepts also null returned from  _getNextFocusableChild