### PR TITLE
fix typo in comments

### DIFF
--- a/_AttachMixin.js
+++ b/_AttachMixin.js
@@ -152,7 +152,7 @@ define([
 			var attachEvent = getAttrFunc(baseNode, "dojoAttachEvent") || getAttrFunc(baseNode, "data-dojo-attach-event");
 			if(attachEvent){
 				// NOTE: we want to support attributes that have the form
-				// "domEvent: nativeEvent; ..."
+				// "domEvent: nativeEvent, ..."
 				var event, events = attachEvent.split(/\s*,\s*/);
 				var trim = lang.trim;
 				while((event = events.shift())){


### PR DESCRIPTION
This was almost too small to worry about but I thought that you guys would appreciate the fix. Thanks for the awesome library.

Related: https://github.com/dojo/docs/pull/137