### PR TITLE
StackContainer: Don't prevent close if onClose is not defined

### DIFF
--- a/layout/StackContainer.js
+++ b/layout/StackContainer.js
@@ -353,7 +353,7 @@ define([
 			//		If onClose() returns true then remove and destroy the child.
 			// tags:
 			//		private
-			var remove = page.onClose && page.onClose(this, page);
+			var remove = !page.onClose || page.onClose(this, page);
 			if(remove){
 				this.removeChild(page);
 				// makes sure we can clean up executeScripts in ContentPane onUnLoad

--- a/tests/layout/test_TabContainer.html
+++ b/tests/layout/test_TabContainer.html
@@ -930,6 +930,11 @@
 			<p>And I was already part of the page! That's cool, no?</p>
 			<p>If you try to close me there should be a confirm dialog.</p>
 		</div>
+		<div data-dojo-type="dijit/layout/ContentPane" data-dojo-props='title:"Fourth", onClose:null, closable:true'>
+			<h1>I am tab 4</h1>
+			<p>I have no onClose function.</p>
+			<p>Clicking the X should close me.</p>
+		</div>
 	</div>
 
 	<p>Tabs with titles on the bottom:</p>


### PR DESCRIPTION
Fixes [#18797](https://bugs.dojotoolkit.org/ticket/18797).

Includes an additional manual test; I didn't see any automated tests for `onClose` in general.  Admittedly setting `onClose` to `null` is a bit contrived, but `_Widget` includes a default `onClose` method that always returns `true`.  This issue mainly crops up with custom widgets extending only `_WidgetBase`, or something like dgrid.