### PR TITLE
fix for #18839: place.around() now works correct in fullscreen mode

### DIFF
--- a/place.js
+++ b/place.js
@@ -286,7 +286,8 @@ define([
 				// ignore nodes between position:relative and position:absolute
 				var sawPosAbsolute = domStyle.getComputedStyle(anchor).position == "absolute";
 				var parent = anchor.parentNode;
-				while(parent && parent.nodeType == 1 && parent.nodeName != "BODY"){  //ignoring the body will help performance
+				var fullScreenNode = document.fullscreenElement || document.fullScreenElement || document.webkitFullscreenElement || document.mozFullScreenElement || document.msFullscreenElement;
+				while(parent && parent.nodeType == 1 && parent != fullScreenNode && parent.nodeName != "BODY"){  //ignoring the body will help performance
 					var parentPos = domGeometry.position(parent, true),
 						pcs = domStyle.getComputedStyle(parent);
 					if(/relative|absolute/.test(pcs.position)){


### PR DESCRIPTION
https://bugs.dojotoolkit.org/ticket/18839
