### PR TITLE
Clear 'item' in Autocomplete widget when textbox cleared in IE

### DIFF
--- a/form/_AutoCompleterMixin.js
+++ b/form/_AutoCompleterMixin.js
@@ -486,6 +486,16 @@ define([
 			}
 			this.inherited(arguments);
 			aspect.after(this, "onSearch", lang.hitch(this, "_openResultList"), true);
+
+			// if the "clear" button is pressed in IE (provided by <input>), then clear the value
+			// must be async since the clearing of the input element happens after the mouseup event 
+			this.on("mouseup", function (e) {
+				setTimeout(lang.hitch(this, function() {
+					if (!e.target.value) {
+						this.set("item", null);
+					}
+				}), 0); 
+			});
 		},
 
 		_getMenuLabelFromItem: function(/*Item*/ item){

--- a/form/_AutoCompleterMixin.js
+++ b/form/_AutoCompleterMixin.js
@@ -7,10 +7,11 @@ define([
 	"dojo/query", // query
 	"dojo/regexp", // regexp.escapeString
 	"dojo/sniff", // has("ie")
+	"dojo/on",
 	"./DataList",
 	"./_TextBoxMixin", // defines _TextBoxMixin.selectInputText
 	"./_SearchMixin"
-], function(aspect, declare, domAttr, keys, lang, query, regexp, has, DataList, _TextBoxMixin, SearchMixin){
+], function(aspect, declare, domAttr, keys, lang, query, regexp, has, on, DataList, _TextBoxMixin, SearchMixin){
 
 	// module:
 	//		dijit/form/_AutoCompleterMixin
@@ -489,13 +490,13 @@ define([
 
 			// if the "clear" button is pressed in IE (provided by <input>), then clear the value
 			// must be async since the clearing of the input element happens after the mouseup event 
-			this.on("mouseup", function (e) {
+			on(this.textbox, "input", lang.hitch(this, function (e) {
 				setTimeout(lang.hitch(this, function() {
 					if (!e.target.value) {
 						this.set("item", null);
 					}
 				}), 0); 
-			});
+			}));
 		},
 
 		_getMenuLabelFromItem: function(/*Item*/ item){

--- a/tests/form/AutoCompleterMixin.html
+++ b/tests/form/AutoCompleterMixin.html
@@ -39,7 +39,9 @@
 				{
 					name: "dijit",
 					runTest: function(){
-						var dijit_attributes = dijit.byId('dijit_attributes');
+						var d = new doh.Deferred(),
+							dijit_attributes = dijit.byId('dijit_attributes');
+
 						doh.is("", dijit_attributes.textbox.value, "dijit original value");
 						doh.is("", dijit_attributes.get('value'), "dijit original get('value')");
 						doh.is(Infinity, dijit_attributes.get('pageSize'), "dijit original get('pageSize')");
@@ -48,6 +50,17 @@
 						doh.is("test", dijit_attributes.textbox.value, "dijit value");
 						doh.is("test", dijit_attributes.get('value'), "dijit get('value')");
 						doh.is(9, dijit_attributes.get('pageSize'), "dijit get('pageSize')");
+						dijit_attributes.set('item', {});
+						dijit_attributes.textbox.value = '';
+						
+						dijit_attributes.on('mouseup', function(){
+							setTimeout(d.getTestCallback(function() {
+								doh.is(null, dijit_attributes.get('item'), 'clears item when textbox emptied');
+							}), 10);
+						});
+						dijit_attributes.emit('mouseup');
+
+						return d;
 					}
 	 			},
 				{

--- a/tests/form/AutoCompleterMixin.html
+++ b/tests/form/AutoCompleterMixin.html
@@ -32,6 +32,7 @@
 		dojo.require("dijit.form.DataList");
 		dojo.require("dijit.form.ComboBox");
 		dojo.require("dojox.mobile.ComboBox");
+		dojo.require("dojo.on");
 
 		dojo.ready(function(){
 
@@ -53,12 +54,12 @@
 						dijit_attributes.set('item', {});
 						dijit_attributes.textbox.value = '';
 						
-						dijit_attributes.on('mouseup', function(){
+						dojo.on(dijit_attributes.textbox, 'input', function(){
 							setTimeout(d.getTestCallback(function() {
 								doh.is(null, dijit_attributes.get('item'), 'clears item when textbox emptied');
 							}), 10);
 						});
-						dijit_attributes.emit('mouseup');
+						dojo.on.emit(dijit_attributes.textbox,'input', {});
 
 						return d;
 					}


### PR DESCRIPTION
Internet Explorer has a "clear" button built into the native input HTML element. This button clears the value of the element, but didn't clear out the underlying value if it was a part of a widget that used the dijit/form/_AutocompleterMixin. This PR adds an event listener to the widget that will set the item to null when this button is pressed.

Fixes [#18862](https://bugs.dojotoolkit.org/ticket/18862)