### PR TITLE
Clear 'item' in Autocomplete widget when textbox cleared in IE

### DIFF
--- a/form/_AutoCompleterMixin.js
+++ b/form/_AutoCompleterMixin.js
@@ -568,6 +568,16 @@ define([
 				value = '';
 			} // null translates to blank
 			this.inherited(arguments);
+		},
+
+		_onInput: function(/*Event*/ evt) {
+			this.inherited(arguments);
+
+			setTimeout(lang.hitch(this, function() {
+				if(!evt.target.value) {
+					this.set("item", null);
+				}
+			}), 0);
 		}
 	});
 

--- a/tests/form/AutoCompleterMixin.html
+++ b/tests/form/AutoCompleterMixin.html
@@ -32,6 +32,7 @@
 		dojo.require("dijit.form.DataList");
 		dojo.require("dijit.form.ComboBox");
 		dojo.require("dojox.mobile.ComboBox");
+		dojo.require("dojo.on");
 
 		dojo.ready(function(){
 
@@ -39,7 +40,8 @@
 				{
 					name: "dijit",
 					runTest: function(){
-						var dijit_attributes = dijit.byId('dijit_attributes');
+						var d = new doh.Deferred(),
+							dijit_attributes = dijit.byId('dijit_attributes');
 						doh.is("", dijit_attributes.textbox.value, "dijit original value");
 						doh.is("", dijit_attributes.get('value'), "dijit original get('value')");
 						doh.is(Infinity, dijit_attributes.get('pageSize'), "dijit original get('pageSize')");
@@ -48,6 +50,17 @@
 						doh.is("test", dijit_attributes.textbox.value, "dijit value");
 						doh.is("test", dijit_attributes.get('value'), "dijit get('value')");
 						doh.is(9, dijit_attributes.get('pageSize'), "dijit get('pageSize')");
+						dijit_attributes.set('item', {});
+						dijit_attributes.textbox.value = '';
+						
+						dojo.on(dijit_attributes.textbox, 'input', function(){
+							setTimeout(d.getTestCallback(function() {
+								doh.is(null, dijit_attributes.get('item'), 'clears item when textbox emptied');
+							}), 10);
+						});
+						dojo.on.emit(dijit_attributes.textbox,'input', {});
+
+						return d;
 					}
 	 			},
 				{


### PR DESCRIPTION
This was originally requested to be pulled under [PR#118](https://github.com/dojo/dijit/pull/118), which was inadvertently closed. In this PR, the new functionality has been added to the _onInput method of the dijit/form/_AutoCompleterMixin per @wkeese's recommendation in the original PR.