### PR TITLE
fix documentation error in dijit/place#around's example

### DIFF
--- a/place.js
+++ b/place.js
@@ -252,7 +252,7 @@ define([
 			//		True if widget is LTR, false if widget is RTL.   Affects the behavior of "above" and "below"
 			//		positions slightly.
 			// example:
-			//	|	placeAroundNode(node, aroundNode, {'BL':'TL', 'TR':'BR'});
+			//	|	placeAroundNode(node, aroundNode, ['below', 'above-alt']);
 			//		This will try to position node such that node's top-left corner is at the same position
 			//		as the bottom left corner of the aroundNode (ie, put node below
 			//		aroundNode, with left edges aligned).	If that fails it will try to put
@@ -305,7 +305,7 @@ define([
 					}
 					parent = parent.parentNode;
 				}
-			}			
+			}
 
 			var x = aroundNodePos.x,
 				y = aroundNodePos.y,


### PR DESCRIPTION
The current API doc shows the use of an object hash to describe how to position the node, however, the function actually takes an array of strings such as ['before', 'above-alt']. This change will align the documentation with the actual implementation