### PR TITLE
Fixes #18888: BackgroundIframe not enabled for IE11/Win10

### DIFF
--- a/BackgroundIframe.js
+++ b/BackgroundIframe.js
@@ -16,7 +16,7 @@ define([
 	// A background iframe is useful to prevent problems with popups appearing behind applets/pdf files,
 	// and is also useful on older versions of IE (IE6 and IE7) to prevent the "bleed through select" problem.
 	// By default, it's enabled for IE6-10, excluding Windows Phone 8,
-	// and it's also enabled for IE11 on Windows 7 and Windows 2008 Server.
+	// and it's also enabled for IE11 on Windows 7, 8, 8.1, 10 and Windows 2008 Server.
 	// TODO: For 2.0, make this false by default.  Also, possibly move definition to has.js so that this module can be
 	// conditionally required via  dojo/has!bgIfame?dijit/BackgroundIframe
 	has.add("config-bgIframe",

--- a/BackgroundIframe.js
+++ b/BackgroundIframe.js
@@ -21,7 +21,7 @@ define([
 	// conditionally required via  dojo/has!bgIfame?dijit/BackgroundIframe
 	has.add("config-bgIframe",
 		(has("ie") && !/IEMobile\/10\.0/.test(navigator.userAgent)) || // No iframe on WP8, to match 1.9 behavior
-		(has("trident") && /Windows NT 6.[01]/.test(navigator.userAgent)));
+		(has("trident") && /Windows NT (?:6.[0123]|10\.0)/.test(navigator.userAgent)));
 
 	var _frames = new function(){
 		// summary:

--- a/BackgroundIframe.js
+++ b/BackgroundIframe.js
@@ -15,13 +15,11 @@ define([
 	// Flag for whether to create background iframe behind popups like Menus and Dialog.
 	// A background iframe is useful to prevent problems with popups appearing behind applets/pdf files,
 	// and is also useful on older versions of IE (IE6 and IE7) to prevent the "bleed through select" problem.
-	// By default, it's enabled for IE6-10, excluding Windows Phone 8,
-	// and it's also enabled for IE11 on Windows 7, 8, 8.1, 10 and Windows 2008 Server.
+	// By default, it's enabled for IE6-11, excluding Windows Phone 8.
 	// TODO: For 2.0, make this false by default.  Also, possibly move definition to has.js so that this module can be
 	// conditionally required via  dojo/has!bgIfame?dijit/BackgroundIframe
 	has.add("config-bgIframe",
-		(has("ie") && !/IEMobile\/10\.0/.test(navigator.userAgent)) || // No iframe on WP8, to match 1.9 behavior
-		(has("trident") && /Windows NT (?:6.[0123]|10\.0)/.test(navigator.userAgent)));
+    	(has("ie") || has("trident")) && !/IEMobile\/10\.0/.test(navigator.userAgent)); // No iframe on WP8, to match 1.9 behavior
 
 	var _frames = new function(){
 		// summary:


### PR DESCRIPTION
Updated user agent testing to determine if BackgroundIFrame is required to work for Windows 8, 8.1 and 10.