### PR TITLE
Fix #18965 preventDefault call with pointer events

### DIFF
--- a/_HasDropDown.js
+++ b/_HasDropDown.js
@@ -110,7 +110,7 @@ define([
 			//
 			// Also, don't call preventDefault() on MSPointerDown event (on IE10) because that prevents the button
 			// from getting focus, and then the focus manager doesn't know what's going on (#17262)
-			if(e.type != "MSPointerDown" && e.type != "pointerdown"){
+			if(e.type != "MSPointerDown"){
 				e.preventDefault();
 			}
 


### PR DESCRIPTION
Fix issue where focusing on a dropdown component inside of a dialog will
cause the dialog to close before the dropdown element gets focus as the
focus manager's stack is cleared before this can happen. This happens in
Chrome 55+ where pointer events now exist.

Issue: https://bugs.dojotoolkit.org/ticket/18965