### PR TITLE
Added isCopy to the set of options that dijit/tree/ObjectStoreModel's…

### DIFF
--- a/tree/ObjectStoreModel.js
+++ b/tree/ObjectStoreModel.js
@@ -245,7 +245,8 @@ define([
 						overwrite: true,
 						parent: newParentItem,
 						oldParent: oldParentItem,
-						before: before
+						before: before,
+						isCopy: false
 					}));
 				}));
 			}else{
@@ -253,7 +254,8 @@ define([
 					overwrite: true,
 					parent: newParentItem,
 					oldParent: oldParentItem,
-					before: before
+					before: before,
+					isCopy: true
 				}));
 			}
 


### PR DESCRIPTION
… pasteItem method passes to the store's put method. This allows the store's put method to distinguish copy from move.