### PR TITLE
Corrects issue editable textboxes in Caret Browsing in IE

### DIFF
--- a/form/_FormValueMixin.js
+++ b/form/_FormValueMixin.js
@@ -4,8 +4,9 @@ define([
 	"dojo/keys", // keys.ESCAPE
 	"dojo/_base/lang",
 	"dojo/on",
+	"dojo/sniff", // has("webkit")
 	"./_FormWidgetMixin"
-], function(declare, domAttr, keys, lang, on, _FormWidgetMixin){
+], function(declare, domAttr, keys, lang, on, has, _FormWidgetMixin){
 
 	// module:
 	//		dijit/form/_FormValueMixin
@@ -26,7 +27,13 @@ define([
 		readOnly: false,
 
 		_setReadOnlyAttr: function(/*Boolean*/ value){
-			domAttr.set(this.focusNode, 'readOnly', value);
+			// IE has a Caret Browsing mode (hit F7 to activate) where disabled textboxes can be modified
+			// focusNode enforced readonly if currently disabled to avoid this issue.
+			if (has('trident') && 'disabled' in this) {
+				domAttr.set(this.focusNode, 'readOnly', value || this.disabled);
+			} else {
+				domAttr.set(this.focusNode, 'readOnly', value);
+			}
 			this._set("readOnly", value);
 		},
 

--- a/form/_FormWidgetMixin.js
+++ b/form/_FormWidgetMixin.js
@@ -75,6 +75,23 @@ define([
 			// Can't use "disabled" in this.focusNode as a test because on IE, that's true for all nodes.
 			if(/^(button|input|select|textarea|optgroup|option|fieldset)$/i.test(this.focusNode.tagName)){
 				domAttr.set(this.focusNode, 'disabled', value);
+				// IE has a Caret Browsing mode (hit F7 to activate) where disabled textboxes can be modified
+				// textboxes marked readonly avoid this issue.
+				// If setting widget disabled and widget is not already readonly, also set readonly.
+				// If setting widget enabled, and this code set readonly, set to non-readonly
+				if(has("trident")){
+					if(value){
+						if(domAttr.get(this.focusNode, 'readonly') === false){
+							domAttr.set(this.focusNode, 'readonly', true);
+							this._disabledSetReadonly = true;
+						}
+					}else{
+						if(this._disabledSetReadonly){
+							domAttr.set(this.focusNode, 'readonly', false);
+							this._disabledSetReadonly = false;
+						}
+					}
+				}
 			}else{
 				this.focusNode.setAttribute("aria-disabled", value ? "true" : "false");
 			}

--- a/form/_FormWidgetMixin.js
+++ b/form/_FormWidgetMixin.js
@@ -76,21 +76,9 @@ define([
 			if(/^(button|input|select|textarea|optgroup|option|fieldset)$/i.test(this.focusNode.tagName)){
 				domAttr.set(this.focusNode, 'disabled', value);
 				// IE has a Caret Browsing mode (hit F7 to activate) where disabled textboxes can be modified
-				// textboxes marked readonly avoid this issue.
-				// If setting widget disabled and widget is not already readonly, also set readonly.
-				// If setting widget enabled, and this code set readonly, set to non-readonly
-				if(has("trident")){
-					if(value){
-						if(domAttr.get(this.focusNode, 'readonly') === false){
-							domAttr.set(this.focusNode, 'readonly', true);
-							this._disabledSetReadonly = true;
-						}
-					}else{
-						if(this._disabledSetReadonly){
-							domAttr.set(this.focusNode, 'readonly', false);
-							this._disabledSetReadonly = false;
-						}
-					}
+				// textboxes marked readonly if disabled to avoid this issue.
+				if (has('trident') && 'readOnly' in this) {
+					domAttr.set(this.focusNode, 'readonly', value || this.readOnly);
 				}
 			}else{
 				this.focusNode.setAttribute("aria-disabled", value ? "true" : "false");


### PR DESCRIPTION
Changes will not allow changes to text boxes in IE when Caret browsing is enabled.  It sets the readonly property of the input tag as well as the disabled property.  When re-enableing it also unsets the readonly property if it changed it in the first place.