### PR TITLE
Allow plugins to override enabled state for their supported commands

### DIFF
--- a/_editor/RichText.js
+++ b/_editor/RichText.js
@@ -1199,6 +1199,15 @@ define([
 
 			return command;
 		},
+		_implCommand: function(/*String*/ cmd){
+			// summary:
+			//		Used as the function name where we might
+			//		find an override for advice on support
+			//		for this command by the target browser.
+			// tags:
+			//		private
+			return  "_" + this._normalizeCommand(cmd) + "EnabledImpl";
+		},
 
 		_qcaCache: {},
 		queryCommandAvailable: function(/*String*/ command){
@@ -1358,7 +1367,7 @@ define([
 			//Check to see if we have any over-rides for commands, they will be functions on this
 			//widget of the form _commandEnabledImpl.  If we don't, fall through to the basic native
 			//command of the browser.
-			var implFunc = "_" + command + "EnabledImpl";
+			var implFunc = this._implCommand(command);
 
 			if(this[implFunc]){
 				return  this[implFunc](command);

--- a/_editor/_Plugin.js
+++ b/_editor/_Plugin.js
@@ -144,7 +144,8 @@ define([
 			var disabled = this.get("disabled");
 			if(this.button){
 				try{
-					enabled = !disabled && e.queryCommandEnabled(c);
+					var implFunc = e._implCommand(c);
+					enabled = !disabled && (this[implFunc] ? this[implFunc](c) : e.queryCommandEnabled(c));
 					if(this.enabled !== enabled){
 						this.enabled = enabled;
 						this.button.set('disabled', !enabled);

--- a/_editor/plugins/LinkDialog.js
+++ b/_editor/plugins/LinkDialog.js
@@ -254,6 +254,16 @@ define([
 			return args;
 		},
 
+		_createlinkEnabledImpl: function() {
+			// summary:
+			//		This function implements the test for if the create link
+			//		command should be enabled or not. This plugin supports
+			//		link creation even without selected text.
+			// tags:
+			//		protected
+			return true;
+		},
+
 		setValue: function(args){
 			// summary:
 			//		Callback from the dialog when user presses "set" button.


### PR DESCRIPTION
As available internally through `RichText`/`Editor`, checking for whether certain commands are enabled can be overridden. This PR exposes this same functionality to plugins so they may also override these checks, though it is only being used for commands the plugins were directly registered with and only to set enabled/disabled state for the toolbar button.

This change was due to the erratic behavior of Internet Explorer, which would return `true` or `false` for `'createLink'` situationally. Because the native `'createLink'` command is expected to be used with a non-zero-length selection, it makes sense for browsers to respond `false` when nothing is selected. But the `LinkDialog` plugin supports zero-length selections – it should always report true, which is supported by enabling and implementing the `_createlinkEnabledImpl` method.