### PR TITLE
Fix #140 - set Editor's document body background color based on the iframe background color

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -819,6 +819,7 @@ define([
 				// is separate from the iframe's document.
 				if(this.document && this.document.body){
 					domStyle.set(this.document.body, "color", domStyle.get(this.iframe, "color"));
+					domStyle.set(this.document.body, "background-color", domStyle.get(this.iframe, "background-color"));
 				}
 			}catch(e){ /* Squelch any errors caused by focus change if hidden during a state change */
 			}


### PR DESCRIPTION
I added a line to copy the Editor's iframe background color to the iframe's document body the same way the foreground color is copied.  This fixes the problem with the hiliteColor plugin always having an initial value of black.

To verify: 
1. Load the dijit test page http://[host]/dijit/tests/editor/test_Editor.html
1. Scroll down to the "Optional toolbar buttons" example.
1. Highlight some text and click the "Background Color" button.

Fixes #140 