### PR TITLE
Fixes for #18695 and #17765

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -1571,10 +1571,20 @@ define([
 			//		Focus on the specified node (which must be visible)
 			// tags:
 			//		protected
-
-			var scrollLeft = this.domNode.scrollLeft;
+                        var focusNode = this.domNode;
+			// finds the node that actually has the "scrollTop" setted
+                        while (focusNode 
+			       && focusNode.scrollTop === 0 
+			       && focusNode.scrollLeft === 0 && focusNode.tagName.toUpperCase() !== 'BODY') {
+                            focusNode = focusNode.parentNode;
+                        }
+			var scrollLeft = focusNode.scrollLeft;
+                        var scrollTop = focusNode.scrollTop || 0;
 			this.focusChild(node);
-			this.domNode.scrollLeft = scrollLeft;
+                        setTimeout(function() {
+				// IE Compatibility
+				window.scrollTo(scrollLeft, scrollTop);
+                        },0)
 		},
 
 		_onNodeMouseEnter: function(/*dijit/_WidgetBase*/ /*===== node =====*/){


### PR DESCRIPTION
Fix for the following issues:

https://bugs.dojotoolkit.org/ticket/18695
https://bugs.dojotoolkit.org/ticket/17765

I deleted the old fix for 17765 because i think is patch (you can see the window scrolling left and right again)

The actual issue was caused because both "scrollTop" and "scrollLeft" returned a "0" value due to bad handling of the "container" that really has the scrollbar on it.

The original code asumed that the "overflow" property is owned by the dijit/Tree instance, this fix searches for it and covers both vertical and horizontal scrolling.