### PR TITLE
ContentPane._onLoadHandler errors don't include a widget id

### DIFF
--- a/layout/ContentPane.js
+++ b/layout/ContentPane.js
@@ -440,7 +440,7 @@ define([
 			try{
 				this.onLoadDeferred.resolve(data);
 			}catch(e){
-				console.error('Error ' + this.widgetId + ' running custom onLoad code: ' + e.message);
+				console.error('Error ' + (this.widgetId || this.id) + ' running custom onLoad code: ' + e.message);
 			}
 		},
 


### PR DESCRIPTION
We have been logging errors in the ContentPane._onLoadHandler() function, but the error messages always have the widgetId as "undefined". Adding this.id when this.widgetId is undefined to try to get back more information about what is causing the error.