### PR TITLE
Fix unnecessary vertical scroll bars if dijit/Dialog beccomes to wide for the viewport

### DIFF
--- a/Dialog.js
+++ b/Dialog.js
@@ -437,14 +437,33 @@ define([
 					viewport.h *= this.maxRatio;
 
 					var bb = domGeometry.position(this.domNode);
-					if(bb.w >= viewport.w || bb.h >= viewport.h){
+					this._shrunk = false;
+					// First check and limit width, because limiting the width may increase the hieght due to word wrapping.
+					if(bb.w >= viewport.w){
 						dim = {
-							w: Math.min(bb.w, viewport.w),
-							h: Math.min(bb.h, viewport.h)
+							w: viewport.w
 						};
+						domGeometry.setMarginBox(this.domNode, dim);
+						bb = domGeometry.position(this.domNode);
 						this._shrunk = true;
-					}else{
-						this._shrunk = false;
+					}
+					// Now check and limit the height
+					if(bb.h >= viewport.h){
+						if(!dim){
+							dim = {
+								w: bb.w
+							};
+						}
+						dim.h = viewport.h;
+						this._shrunk = true;
+					}
+					if(dim){
+						if(!dim.w){
+							dim.w = bb.w;
+						}
+						if(!dim.h){
+							dim.h = bb.h;
+						}
 					}
 				}
 


### PR DESCRIPTION
This is my first try to fix unnecessary vertical scroll bars if dijit/Dialog becomes to wide for the viewport (#154). The idea is to first check the width and limit it to the viewport, then check the new height. Limiting the width may change the hieght due to word wrapping.
I need to call domGeometry.setMarginBox() in the upper part of the function. Until now it was only called in the lower part of the function. Maybe that's a problem.