### PR TITLE
Fix #161: Tree: disable user select with CSS in Firefox

### DIFF
--- a/themes/dijit.css
+++ b/themes/dijit.css
@@ -1584,6 +1584,7 @@ div.dijitTabDisabled, .dj_ie div.dijitTabDisabled {
 .dijitTree {
 	overflow: auto;	/* for scrollbars when Tree has a height setting, and to prevent wrapping around float elements, see #11491 */
 	-webkit-tap-highlight-color: transparent;
+	-moz-user-select: none;
 }
 
 .dijitTreeContainer {


### PR DESCRIPTION
`dijit/Tree` and `dojo/dnd/Manager` both have `selectstart` handlers that prevent
selection, and they are generally working. In Firefox, although the handlers
fire and prevent actual content selection, for the purpose of pointer events
Firefox behaves as if selection is happening. An extra `mousemove` handler
added for debugging shows that wherever the mouse moves, the event target
continues to be the tree node. This means that `mouseover/mouseenter` events
on the DnD target node outside the tree are never fired.

Fixes #161