### PR TITLE
DateTimeTextBox: add secondary range check for partial year values

### DIFF
--- a/form/_DateTimeTextBox.js
+++ b/form/_DateTimeTextBox.js
@@ -183,6 +183,43 @@ define([
 			this._unboundedConstraints = lang.mixin({}, this.constraints, {min: null, max: null});
 		},
 
+		_isDefinitelyOutOfRange: function(){
+			var returnValue = this.inherited(arguments);
+			var isOutOfRange = false;
+			var inputDate;
+			var inputYear;
+			var inputYearMax;
+			var inputYearMin;
+			var maxDate;
+			var minDate;
+
+			if(returnValue && (this.constraints.min || this.constraints.max)){
+				dateRegExp = new RegExp(this._lastRegExp);
+				inputDate = dateRegExp.exec(this._lastInputEventValue);
+				inputYear = inputDate[3];
+
+				if(this.constraints.min){
+					minDate = this.constraints.min instanceof Date ?
+						this.constraints.min : new Date(String(this.constraints.min));
+					minYear = minDate.getFullYear();
+					inputYearMax = parseInt((inputYear + '9999').substr(0, 4), 10);
+					isOutOfRange = inputYearMax < minYear;
+				}
+
+				if(!isOutOfRange && this.constraints.max){
+					maxDate = this.constraints.max instanceof Date ?
+						this.constraints.max : new Date(String(this.constraints.max));
+					maxYear = maxDate.getFullYear();
+					inputYearMin = parseInt((inputYear + '0000').substr(0, 4), 10);
+					isOutOfRange = inputYearMin > maxYear;
+				}
+
+				returnValue = isOutOfRange;
+			}
+
+			return returnValue;
+		},
+
 		_isInvalidDate: function(/*Date*/ value){
 			// summary:
 			//		Runs various tests on the value, checking for invalid conditions


### PR DESCRIPTION
DateTimeTextBox accepts as input 2 digit or 4 digit years. However, while
validating the value it is always converted to a 4 digit year. This results
in the UI potentially reporting a partial year as invalid, e.g. when
"5/5/20" is interpreted as "5/5/2020". The user could be in the process of
typing "5/5/2005". This change adds secondary range checking with logic to
handle partial years.

Fixes #148