### PR TITLE
Tree DnD: add dojo/store example to manual test page

### DIFF
--- a/tests/_data/categories.json
+++ b/tests/_data/categories.json
@@ -2,10 +2,10 @@
 	"identifier": "id",
 	"label": "name",
 	"items": [
-		{ "id": "0", "name":"Foods", "numberOfItems":1, "children":[ {"_reference": "1"},  {"_reference": "2"},  {"_reference": "3"} ] },
-			{ "id": "1", "name":"Fruits", "numberOfItems":1, "children":[ {"_reference": "4"} ] },
-				{ "id": "4","name":"Citrus", "numberOfItems":1, "items":[ {"_reference": "5"} ] },
-					{ "id": "5", "name":"Orange"},
+		{ "id": "0", "name":"Foods", "numberOfItems":3, "children":[ {"_reference": "1"},  {"_reference": "2"},  {"_reference": "3"} ] },
+		{ "id": "1", "name":"Fruits", "numberOfItems":1, "children":[ {"_reference": "4"} ] },
+		{ "id": "4", "name":"Citrus", "numberOfItems":1, "items":[ {"_reference": "5"} ] },
+		{ "id": "5", "name":"Orange"},
 		{ "id": "2", "name":"Vegetables", "numberOfItems":0},
 		{ "id": "3", "name":"Cereals", "numberOfItems":0}
 	]

--- a/tests/tree/test_Tree_DnD.html
+++ b/tests/tree/test_Tree_DnD.html
@@ -9,12 +9,107 @@
 		@import "../../../dojo/tests/dnd/dndDefault.css";
 	</style>
 
+	<style>
+		.myFolder{
+			width: 16px;
+			height: 16px;
+			background: blue;
+		}
+
+		.myItem{
+			width: 16px;
+			height: 16px;
+			background: green;
+
+		}
+	</style>
+</head>
+
+<body class="claro" role="main">
+	<h1 class="testTitle">Dijit Tree Test - Drag And Drop Support</h1>
+
+	<h2>Dojo.data (<code>dojo/data</code>) Examples</h2>
+	<div>
+		<div role="presentation" style="display: inline-block; vertical-align: top; width: 49%;">
+			<h3>Items: </h3>
+			<p>List of Items to be categorized</p>
+			<div data-dojo-id="c2" data-dojo-type="dojo/dnd/Source" class="container" style="height:175px; overflow:auto;">
+				<div class="dojoDndItem" id="1001">Apple</div>
+				<div class="dojoDndItem" id="1002">Orange</div>
+				<div class="dojoDndItem" id="1003">Banana</div>
+				<div class="dojoDndItem" id="1004">Tomato</div>
+				<div class="dojoDndItem" id="1005">Pepper</div>
+				<div class="dojoDndItem" id="1006">Wheat</div>
+				<div class="dojoDndItem" id="1007">Corn</div>
+				<div class="dojoDndItem" id="1008">Spinach</div>
+				<div class="dojoDndItem" id="1009">Cucumber</div>
+				<div class="dojoDndItem" id="1010">Carrot</div>
+				<div class="dojoDndItem" id="1011">Potato</div>
+				<div class="dojoDndItem" id="1012">Grape</div>
+				<div class="dojoDndItem" id="1013">Lemon</div>
+				<div class="dojoDndItem" id="1014">Lettuce</div>
+				<div class="dojoDndItem" id="1015">Peanut</div>
+			</div>
+		</div>
+
+		<div role="presentation" style="display: inline-block; width: 49%;">
+			<h3>Collection</h3>
+			<p>
+				Drop items from table on left onto this tree, only on to categories or between other items; should fail to let you drop on other items.
+				Can also move items within this tree. The drag threshold is set to 8, between threshold is set to 5, so you have a few pixels
+				of buffer before drag operations start.
+			</p>
+			<div data-dojo-id="itemModel"
+				data-dojo-type="dijit/tree/TreeStoreModel"
+				data-dojo-props="store: myStore,
+					query: {id: '0'},
+					childrenAttrs: ['items', 'children']">
+			</div>
+			<div id="itemTree"
+				data-dojo-type="dijit/Tree"
+				data-dojo-props="'class': 'container',
+					model: itemModel,
+					checkAcceptance: dndAccept,
+					checkItemAcceptance: itemTreeCheckItemAcceptance,
+					dragThreshold: 8,
+					betweenThreshold: 5,
+					getIconClass: getIcon,
+					persist: false">
+			</div>
+		</div>
+	</div>
+
+	<h3>Collection Count Summary</h3>
+	<p>
+		You can't drop items onto this tree, but you can reorder categories. The between threshold
+		is set to 5, so if you are near the top or bottom of a node the drop will be above or below it.
+	</p>
+	<div id="collectionsTree"
+		data-dojo-type="dijit/Tree"
+		data-dojo-props="'class': 'container',
+			model: catModel,
+			getLabel: catTreeCustomLabel,
+			betweenThreshold: 5,
+			checkAcceptance: dndAccept,
+			checkItemAcceptance: collectionTreeCheckItemAcceptance,
+			getIconClass: getIcon,
+			persist: false">
+	</div>
+
+	<h3>Custom</h3>
+	<p>Should add this category to the store.  The second parameter is the value for numberOfItems.</p>
+	<div class="container">
+		<label for="newCat">New category:</label><input id="newCat" type="text" value="Pottedmeat" />
+		<label for="numItems">numberOfItems:</label><input id="numItems" type="text" value="0" size="3"/>
+		<div id="addButton" data-dojo-type="dijit/form/Button">Add Category</div>
+	</div>
+
 	<script type="text/javascript" src="../boilerplate.js"></script>
 
 	<script type="text/javascript">
+		/* dojo/data examples */
 		require([
 			"dojo/aspect",
-			"dojo/dnd/Source",
 			"dojo/data/ItemFileWriteStore",
 			"dojo/dom",
 			"dojo/parser",
@@ -23,12 +118,11 @@
 			"dijit/Tree",
 			"dijit/tree/TreeStoreModel",
 			/testController=selector/.test(window.location.search) ? "dijit/tree/_dndSelector" : "dijit/tree/dndSource",
+			"dojo/dnd/Source",
 			"dijit/Menu",
 			"dijit/form/Button",
-			"dijit/focus",	// not used directly, but needed by robot test drivers, ex: Tree_Selector.html
-			"dojo/domReady!"
-		], function(aspect, Source, ItemFileWriteStore, dom, parser, topic,
-					registry, Tree, TreeStoreModel, testController){
+			"dijit/focus"	// not used directly, but needed by robot test drivers, ex: Tree_Selector.html
+		], function(aspect, ItemFileWriteStore, dom, parser, topic, registry, Tree, TreeStoreModel, testController){
 
 			myStore = new ItemFileWriteStore({
 				url: "../_data/categories.json"
@@ -81,10 +175,10 @@
 			parser.parse();
 
 			selected = [];
-	
+
 			globalId = 1000;
 			lastSelected = null;
-	
+
 			// record the selection from tree 1
 			topic.subscribe("myTree", function(message){
 				if(message.event == "execute"){
@@ -128,78 +222,5 @@
 			}, true);
 		});
 	</script>
-
-	<style>
-		.myFolder{
-			width: 16px;
-			height: 16px;
-			background: blue;
-		}
-
-		.myItem{
-			width: 16px;
-			height: 16px;
-			background: green;
-
-		}
-	</style>
-
-</head>
-<body class="claro" role="main">
-	<h1 class="testTitle">Dijit Tree Test - Drag And Drop Support</h1>
-
-	<div role="presentation" style="float: left; width: 50%;">
-
-		<h2>Items: </h2>
-		<p>List of Items to be categorized<p>
-			<div data-dojo-id="c2" data-dojo-type="dojo/dnd/Source" class="container" style="height:100px; overflow:auto;">
-			<div class="dojoDndItem" id="1001">Apple</div>
-			<div class="dojoDndItem" id="1002">Orange</div>
-			<div class="dojoDndItem" id="1003">Banana</div>
-			<div class="dojoDndItem" id="1004">Tomato</div>
-			<div class="dojoDndItem" id="1005">Pepper</div>
-			<div class="dojoDndItem" id="1006">Wheat</div>
-			<div class="dojoDndItem" id="1007">Corn</div>
-			<div class="dojoDndItem" id="1008">Spinach</div>
-			<div class="dojoDndItem" id="1009">Cucumber</div>
-			<div class="dojoDndItem" id="1010">Carrot</div>
-			<div class="dojoDndItem" id="1011">Potato</div>
-			<div class="dojoDndItem" id="1012">Grape</div>
-			<div class="dojoDndItem" id="1013">Lemon</div>
-			<div class="dojoDndItem" id="1014">Lettuce</div>
-			<div class="dojoDndItem" id="1015">Peanut</div>
-		</div>
-
-		<h2>Collection Count Summary</h2>
-		<p>
-			You can't drop items onto this tree, but you can reorder categories. The between threshold
-			is set to 5, so if you are near the top or bottom of a node the drop will be above or below it.
-		</p>
-		<div id="collectionsTree" data-dojo-type="dijit/Tree" data-dojo-props='"class":"container", model:catModel,
-			getLabel:catTreeCustomLabel, betweenThreshold:5,
-			checkAcceptance:dndAccept, checkItemAcceptance:collectionTreeCheckItemAcceptance, getIconClass:getIcon,
-			persist:false'></div>
-
-		<h2>Custom</h2>
-		<p>Should add this category to the store.  The second parameter is the value for numberOfItems.</p>
-		<div class="container">
-			<label for="newCat">New category:</label><input id="newCat" type="text" value="Pottedmeat" /><label for="numItems">numberOfItems:</label><input id="numItems" type="text" value="0" size="3"/><div id="addButton" data-dojo-type="dijit/form/Button">Add Category</div>
-		</div>
-	</div>
-
-	<h2>Collection</h2>
-	<p>
-		Drop items from table on left onto this tree, only on to categories or between other items; should fail to let you drop on other items.
-		Can also move items within this tree. The drag threshold is set to 8, between threshold is set to 5, so you have a few pixels
-		of buffer before drag operations start.
-	</p>
-	<div data-dojo-id="itemModel" data-dojo-type="dijit/tree/TreeStoreModel" data-dojo-props='store:myStore, query:{id: "0"}, childrenAttrs:["items", "children"]'></div>
-	<div id="itemTree" data-dojo-type="dijit/Tree" data-dojo-props='"class":"container", model:itemModel,
-		checkAcceptance:dndAccept, checkItemAcceptance:itemTreeCheckItemAcceptance,
-		dragThreshold:8,
-		betweenThreshold:5,
-		getIconClass:getIcon,
-		persist:false'></div>
-
-	</body>
+</body>
 </html>

--- a/tests/tree/test_Tree_DnD.html
+++ b/tests/tree/test_Tree_DnD.html
@@ -161,34 +161,6 @@
 				}
 			});
 
-			var MyModel = ObjectStoreModel.createSubclass([], {
-				newItem: function(args, parent){
-					this.inherited(arguments);
-					if(parent){
-						this._updateChildrenCache(parent);
-					}
-				},
-
-				pasteItem: function(item, oldParent, newParent){
-					this.inherited(arguments);
-					if(oldParent !== newParent){
-						this._updateChildrenCache(oldParent);
-						this._updateChildrenCache(newParent);
-					}
-				},
-
-				_updateChildrenCache: function(parent){
-					this.childrenCache[this.getIdentity(parent)] = undefined;
-					var onGetChildren = lang.hitch(this, function(children){
-						this.onChildrenChange(parent, children);
-					});
-					var onError = lang.hitch(this, function(error){
-						throw (error || "Error getting children for: " + this.getIdentity(parent));
-					});
-					this.getChildren(parent, onGetChildren, onError);
-				}
-			});
-
 			function transformData(data){
 				arrayUtil.forEach(data, function(item){
 					var children = item.children || item.items || [];
@@ -214,7 +186,7 @@
 				data: transformData(JSON.parse(categoriesJson).items)
 			}));
 
-			memoryStoreModel = new MyModel({
+			memoryStoreModel = new ObjectStoreModel({
 				store: memoryStore,
 				query: { id: "0" },
 				mayHaveChildren: function(item){
@@ -254,6 +226,8 @@
 			"dojo/topic",
 			"dijit/registry",
 			"dijit/tree/TreeStoreModel",
+
+			// for parser
 			"dojo/dnd/Source",
 			"dijit/Menu",
 			"dijit/form/Button",

--- a/tests/tree/test_Tree_DnD.html
+++ b/tests/tree/test_Tree_DnD.html
@@ -28,6 +28,14 @@
 <body class="claro" role="main">
 	<h1 class="testTitle">Dijit Tree Test - Drag And Drop Support</h1>
 
+	<h2>Dojo Object Store (<code>dojo/store</code>) Examples</h2>
+
+	<p>
+		You can't drop items onto this tree, but you can reorder categories. The between threshold
+		is set to 5, so if you are near the top or bottom of a node the drop will be above or below it.
+	</p>
+	<div id="memoryStoreTree"></div>
+
 	<h2>Dojo.data (<code>dojo/data</code>) Examples</h2>
 	<div>
 		<div role="presentation" style="display: inline-block; vertical-align: top; width: 49%;">
@@ -69,7 +77,6 @@
 				data-dojo-type="dijit/Tree"
 				data-dojo-props="'class': 'container',
 					model: itemModel,
-					checkAcceptance: dndAccept,
 					checkItemAcceptance: itemTreeCheckItemAcceptance,
 					dragThreshold: 8,
 					betweenThreshold: 5,
@@ -90,7 +97,6 @@
 			model: catModel,
 			getLabel: catTreeCustomLabel,
 			betweenThreshold: 5,
-			checkAcceptance: dndAccept,
 			checkItemAcceptance: collectionTreeCheckItemAcceptance,
 			getIconClass: getIcon,
 			persist: false">
@@ -107,6 +113,132 @@
 	<script type="text/javascript" src="../boilerplate.js"></script>
 
 	<script type="text/javascript">
+		/* dojo/store examples */
+		require([
+			"dojo/_base/array",
+			"dojo/_base/lang",
+			"dojo/dom",
+			"dojo/store/Memory",
+			"dojo/store/Observable",
+			"dijit/Tree",
+			/testController=selector/.test(window.location.search) ? "dijit/tree/_dndSelector" : "dijit/tree/dndSource",
+			"dijit/tree/ObjectStoreModel",
+			"dojo/text!../_data/categories.json"
+		], function(arrayUtil, lang, dom, MemoryStore, Observable, Tree, testController, ObjectStoreModel, categoriesJson){
+			Tree.prototype.dndController = testController;
+
+			var TreeStore = MemoryStore.createSubclass([Observable], {
+				getChildren: function(item){
+					return this.query({parentId: item.id});
+				},
+
+				mayHaveChildren: function(item){
+					return Boolean(item.numberOfItems);
+				},
+				put: function(object, options){
+					var id = this.inherited(arguments);
+					if(options && (options.parent !== options.oldParent)){
+						object.parentId = this.getIdentity(options.parent);
+						if(isNaN(options.parent.numberOfItems)){
+							options.parent.numberOfItems = 1;
+						}
+						else{
+							options.parent.numberOfItems += 1;
+						}
+						this.put(options.parent);
+
+						if(options.oldParent){
+							options.oldParent.numberOfItems = Math.max(0, options.oldParent.numberOfItems - 1);
+							this.put(options.oldParent);
+						}
+					}
+				}
+			});
+
+			var MyModel = ObjectStoreModel.createSubclass([], {
+				newItem: function(args, parent){
+					this.inherited(arguments);
+					if(parent){
+						this._updateChildrenCache(parent);
+					}
+				},
+
+				pasteItem: function(item, oldParent, newParent){
+					this.inherited(arguments);
+					if(oldParent !== newParent){
+						this._updateChildrenCache(oldParent);
+						this._updateChildrenCache(newParent);
+					}
+				},
+
+				_updateChildrenCache: function(parent){
+					this.childrenCache[this.getIdentity(parent)] = undefined;
+					var onGetChildren = lang.hitch(this, function(children){
+						this.onChildrenChange(parent, children);
+					});
+					var onError = lang.hitch(this, function(error){
+						throw (error || "Error getting children for: " + this.getIdentity(parent));
+					});
+					this.getChildren(parent, onGetChildren, onError);
+				}
+			});
+
+			function transformData(data){
+				arrayUtil.forEach(data, function(item){
+					var children = item.children || item.items || [];
+
+					arrayUtil.forEach(children, function(child){
+						var childItem = arrayUtil.filter(data, function (o) {
+							return o.id === child._reference;
+						})[0];
+
+						if(childItem){
+							childItem.parentId = item.id;
+						}
+					});
+
+					item.children = undefined;
+					item.items = undefined;
+				});
+
+				return data;
+			}
+
+			memoryStore = new TreeStore({
+				data: transformData(JSON.parse(categoriesJson).items)
+			});
+
+			memoryStoreModel = new MyModel({
+				store: memoryStore,
+				query: { id: "0" },
+				mayHaveChildren: function(item){
+					return Boolean(item.numberOfItems);
+				}
+			});
+
+			function getLabel(item){
+				return item.name + (item.numberOfItems ? (" (" + (item.numberOfItems || "0") + ")") : "");
+			};
+
+			function getIcon(item){
+				return ("numberOfItems" in item) ? "myFolder" : "myItem";
+			};
+
+			memoryStoreTree = new Tree({
+				className: "container",
+				model: memoryStoreModel,
+				betweenThreshold: 5,
+				persist: false,
+				getLabel: getLabel,
+				checkItemAcceptance: function(node, source){
+					return source.tree && source.tree.id === "memoryStoreTree";
+				},
+				getIconClass: getIcon
+			}, dom.byId("memoryStoreTree"));
+		});
+	</script>
+
+	<script type="text/javascript">
 		/* dojo/data examples */
 		require([
 			"dojo/aspect",
@@ -115,14 +247,13 @@
 			"dojo/parser",
 			"dojo/topic",
 			"dijit/registry",
-			"dijit/Tree",
 			"dijit/tree/TreeStoreModel",
-			/testController=selector/.test(window.location.search) ? "dijit/tree/_dndSelector" : "dijit/tree/dndSource",
 			"dojo/dnd/Source",
 			"dijit/Menu",
 			"dijit/form/Button",
-			"dijit/focus"	// not used directly, but needed by robot test drivers, ex: Tree_Selector.html
-		], function(aspect, ItemFileWriteStore, dom, parser, topic, registry, Tree, TreeStoreModel, testController){
+			"dijit/focus",	// not used directly, but needed by robot test drivers, ex: Tree_Selector.html
+			"dijit/Tree"
+		], function(aspect, ItemFileWriteStore, dom, parser, topic, registry, TreeStoreModel){
 
 			myStore = new ItemFileWriteStore({
 				url: "../_data/categories.json"
@@ -140,6 +271,11 @@
 				return label + ' (' + num+ ')';
 			};
 
+			// on collection tree, only accept itself as the source tree
+			collectionTreeCheckItemAcceptance = function(node, source, position){
+				return source.tree && source.tree.id == "collectionsTree";
+			}
+
 			//on item tree , we want to drop on containers, the root node itself, or between items in the containers
 			itemTreeCheckItemAcceptance = function(node, source, position){
 				/*
@@ -154,23 +290,12 @@
 				return position != "over";
 			};
 
-			// on collection tree, only accept itself as the source tree
-			collectionTreeCheckItemAcceptance = function(node,source,position){
-				return source.tree && source.tree.id == "collectionsTree";
-			};
-
-			dndAccept = function(source, nodes){
-				return this.tree.id != "myTree";
-			};
-
 			getIcon = function(item){
 				if(!item || myStore.hasAttribute(item, "numberOfItems")){
 					return "myFolder";
 				}
 				return "myItem"
 			};
-
-			Tree.prototype.dndController = testController;
 
 			parser.parse();
 

--- a/tests/tree/test_Tree_DnD.html
+++ b/tests/tree/test_Tree_DnD.html
@@ -127,7 +127,7 @@
 		], function(arrayUtil, lang, dom, MemoryStore, Observable, Tree, testController, ObjectStoreModel, categoriesJson){
 			Tree.prototype.dndController = testController;
 
-			var TreeStore = MemoryStore.createSubclass([Observable], {
+			var TreeStore = MemoryStore.createSubclass([], {
 				getChildren: function(item){
 					return this.query({parentId: item.id});
 				},
@@ -135,10 +135,14 @@
 				mayHaveChildren: function(item){
 					return Boolean(item.numberOfItems);
 				},
+
 				put: function(object, options){
 					var id = this.inherited(arguments);
-					if(options && (options.parent !== options.oldParent)){
-						object.parentId = this.getIdentity(options.parent);
+					var parentId = options && options.parent && this.getIdentity(options.parent);
+					var oldParentId = options && options.oldParent && this.getIdentity(options.oldParent);
+
+					if(parentId !== oldParentId){
+						object.parentId = parentId;
 						if(isNaN(options.parent.numberOfItems)){
 							options.parent.numberOfItems = 1;
 						}
@@ -152,6 +156,8 @@
 							this.put(options.oldParent);
 						}
 					}
+
+					return id;
 				}
 			});
 
@@ -204,9 +210,9 @@
 				return data;
 			}
 
-			memoryStore = new TreeStore({
+			memoryStore = new Observable(new TreeStore({
 				data: transformData(JSON.parse(categoriesJson).items)
-			});
+			}));
 
 			memoryStoreModel = new MyModel({
 				store: memoryStore,

--- a/tree/ObjectStoreModel.js
+++ b/tree/ObjectStoreModel.js
@@ -203,12 +203,6 @@ define([
 			// summary:
 			//		Creates a new item.   See `dojo/data/api/Write` for details on args.
 			//		Used in drag & drop when item from external source dropped onto tree.
-
-			// adding a new child invalidates the childrenCache for the parent
-			if(parent){
-				this.childrenCache[this.getIdentity(parent)] = undefined;
-			}
-
 			return this.store.put(args, {
 				parent: parent,
 				before: before
@@ -229,15 +223,6 @@ define([
 				// that the childItem was added/moved.
 				d.resolve(true);
 				return d;
-			}
-
-			if(newParentItem !== oldParentItem){
-				if(newParentItem){
-					this.childrenCache[this.getIdentity(newParentItem)] = undefined;
-				}
-				if(oldParentItem){
-					this.childrenCache[this.getIdentity(oldParentItem)] = undefined;
-				}
 			}
 
 			if(oldParentItem && !bCopy){

--- a/tree/ObjectStoreModel.js
+++ b/tree/ObjectStoreModel.js
@@ -203,6 +203,7 @@ define([
 			// summary:
 			//		Creates a new item.   See `dojo/data/api/Write` for details on args.
 			//		Used in drag & drop when item from external source dropped onto tree.
+
 			return this.store.put(args, {
 				parent: parent,
 				before: before

--- a/tree/ObjectStoreModel.js
+++ b/tree/ObjectStoreModel.js
@@ -204,6 +204,11 @@ define([
 			//		Creates a new item.   See `dojo/data/api/Write` for details on args.
 			//		Used in drag & drop when item from external source dropped onto tree.
 
+			// adding a new child invalidates the childrenCache for the parent
+			if(parent){
+				this.childrenCache[this.getIdentity(parent)] = undefined;
+			}
+
 			return this.store.put(args, {
 				parent: parent,
 				before: before
@@ -224,6 +229,15 @@ define([
 				// that the childItem was added/moved.
 				d.resolve(true);
 				return d;
+			}
+
+			if(newParentItem !== oldParentItem){
+				if(newParentItem){
+					this.childrenCache[this.getIdentity(newParentItem)] = undefined;
+				}
+				if(oldParentItem){
+					this.childrenCache[this.getIdentity(oldParentItem)] = undefined;
+				}
 			}
 
 			if(oldParentItem && !bCopy){


### PR DESCRIPTION
The [manual test page for Tree DnD](https://github.com/dojo/dijit/blob/7d9d4927a26a246719e153c1fad557b9a956eb60/tests/tree/test_Tree_DnD.html) demonstrates using `dijit/Tree` with the Dojo Data API (`dojo/data`), but not with the Dojo Object Store API (`dojo/store`). As of Dojo 1.16.3 `dojo/store/Memory` and `dojo/store/Observable` lack support for the `options.before` parameter to the `add` and `put` methods. This PR adds an example to the Dijit Tree test page that works with the `dojo/store` updates in dojo/dojo#382

Closes #170 (depends on dojo/dojo#382)