### PR TITLE
avoid autocasting when comparing with dojo/key-constants

### DIFF
--- a/form/_SearchMixin.js
+++ b/form/_SearchMixin.js
@@ -133,7 +133,7 @@ define([
 
 			this._prev_key_backspace = false;
 
-			if (key == keys.DELETE || key == keys.BACKSPACE) {
+			if (key === keys.DELETE || key === keys.BACKSPACE) {
 				this._prev_key_backspace = true;
 				this._maskValidSubsetError = true;
 			}


### PR DESCRIPTION
use strict comparison to avoid autocasting fixing #185 