### PR TITLE
Change block-scoped functions to named function expressions

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -384,7 +384,7 @@ define([
 						tree.dndController.removeTreeNode(node);
 
 						// Deregister mapping from item id --> this node and its descendants
-						function remove(node){
+						var remove = function remove(node){
 							var id = model.getIdentity(node.item),
 								ary = tree._itemNodesMap[id];
 							if(ary.length == 1){
@@ -396,7 +396,7 @@ define([
 								}
 							}
 							array.forEach(node.getChildren(), remove);
-						}
+						};
 
 						remove(node);
 
@@ -1572,7 +1572,7 @@ define([
 			// tags:
 			//		protected
                         var tmp = [];
-                        for(var domNode = this.domNode; 
+                        for(var domNode = this.domNode;
                             domNode && domNode.tagName && domNode.tagName.toUpperCase() !== 'IFRAME';
                             domNode = domNode.parentNode) {
                             tmp.push({


### PR DESCRIPTION
With the addition of block scope to ES6 it has become impractical for tools like Google Closure Compiler to handle block-scoped functions in pre-ES6 code and they are flagged as errors.

This PR ensures that `dijit` can still be built if the build profile sets `optimizeOptions.languageIn` to `'ECMASCRIPT3'` with versions of Google Closure Compiler that support ES6. See dojo/util#83