### PR TITLE
Remove an instance of an unsafe-eval in _FormSelectWidget getOptions

### DIFF
--- a/form/_FormSelectWidget.js
+++ b/form/_FormSelectWidget.js
@@ -144,7 +144,9 @@ define([
 				return opts; // __SelectOption[]
 			}
 			if(lang.isArrayLike(valueOrIdx)){
-				return array.map(valueOrIdx, "return this.getOptions(item);", this); // __SelectOption[]
+				return array.map(valueOrIdx, function(item){
+					return this.getOptions(item);
+				}, this); // __SelectOption[]
 			}
 			if(lang.isString(valueOrIdx)){
 				valueOrIdx = { value: valueOrIdx };


### PR DESCRIPTION
Fixes an incompatibility with using a content-security-policy headerwhich lacks the unsafe-eval directive.