### PR TITLE
MenuItem: no extra space in aria-label when no accelKey is set

### DIFF
--- a/MenuItem.js
+++ b/MenuItem.js
@@ -45,7 +45,7 @@ define([
 			}else{
 				text = val;
 			}
-			this.domNode.setAttribute("aria-label", text + " " + this.accelKey);
+			this.domNode.setAttribute("aria-label", text + (this.accelKey ? " " + this.accelKey : ""));
 			this.containerNode.innerHTML = val;
 			this._set('shortcutKey', shortcutKey);
 		},


### PR DESCRIPTION
Also, fix aria-label when accelKey is set to `undefined` or `null`.