### PR TITLE
Fix call to _onHide in StackContainer._hideChild

### DIFF
--- a/layout/StackContainer.js
+++ b/layout/StackContainer.js
@@ -344,7 +344,7 @@ define([
 				domClass.replace(page._wrapper, "dijitHidden", "dijitVisible");
 			}
 
-			page.onHide && page.onHide();
+			page._onHide && page._onHide();
 		},
 
 		closeChild: function(/*dijit/_WidgetBase*/ page){


### PR DESCRIPTION
**Update:** do not merge! While `_Widget` has both `_onShow` and `onShow`, it has only `onHide`, but not `_onHide`. That's very confusing.

See `_showChild` code or `_hideChild` comment: 
```
Hide the specified child by changing it's CSS, and call _onHide() so
```

but `onHide()` was called instead. Fixed this to proper `_onHide()`