### PR TITLE
fix(a11y): declare aria-expanded and aria-controls on combobox at startup

### DIFF
--- a/form/_AutoCompleterMixin.js
+++ b/form/_AutoCompleterMixin.js
@@ -484,6 +484,9 @@ define([
 				this.domNode.setAttribute("aria-labelledby", label[0].id);
 
 			}
+			// ARIA 1.1 combobox requires aria-controls pointing at the popup widget.
+			// The popup is always created with id = this.id + "_popup".
+			this.domNode.setAttribute("aria-controls", this.id + "_popup");
 			this.inherited(arguments);
 			aspect.after(this, "onSearch", lang.hitch(this, "_openResultList"), true);
 		},

--- a/form/templates/DropDownBox.html
+++ b/form/templates/DropDownBox.html
@@ -2,6 +2,7 @@
 	id="widget_${id}"
 	role="combobox"
 	aria-haspopup="true"
+	aria-expanded="false"
 	data-dojo-attach-point="_popupStateNode"
 	><div class='dijitReset dijitRight dijitButtonNode dijitArrowButton dijitDownArrowButton dijitArrowButtonContainer'
 		data-dojo-attach-point="_buttonNode" role="presentation"


### PR DESCRIPTION
## Problem

`role=combobox` requires both `aria-expanded` and `aria-controls` to be present per ARIA 1.1 (WCAG 2.1 SC 4.1.2). Currently:

- `aria-expanded` is toggled `true`/`false` in `_showResultList()` and `closeDropDown()` but is **absent from the template**, so axe-core's [aria-required-attr](https://dequeuniversity.com/rules/axe/4.10/aria-required-attr) rule fires on every page load before the user has interacted with the widget.
- `aria-controls` is **never set** at all — only `aria-owns` is set (in `_HasDropDown.openDropDown()`), which is the ARIA 1.0 pattern.

## Fix

- **`form/templates/DropDownBox.html`**: add `aria-expanded="false"` to the root `div` alongside the existing `aria-haspopup="true"`
- **`form/_AutoCompleterMixin.postCreate`**: set `aria-controls="{id}_popup"` eagerly — the popup widget is always created with `id = this.id + '_popup'` (see `_startSearchFromInput`)

## Testing

Verified with [axe-core](https://github.com/dequelabs/axe-core) via `@axe-core/playwright` against a production Dojo 1.17 application. Before this fix, `aria-required-attr` fired on every `FilteringSelect` on page load. After this fix, no violations.